### PR TITLE
fix: OSS release audit — security, types, config, and test hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+data
+.env
+logs
+.cloudflared
+proxy-certs
+proxy-data
+.git
+.claude

--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,15 @@ NODE_ENV=production
 # Data storage (use /app/data for Docker, ./data for local dev)
 DATA_DIR=/app/data
 
+# Comma-separated list of allowed origins. Default: https://claude.ai,https://claude.com
+# CORS_ORIGINS=https://claude.ai,https://claude.com
+
 # ── Tier 2: PostgreSQL (Tasks + FTS) ───────────────────
 
 POSTGRES_DB=context_library
 POSTGRES_USER=cl
-POSTGRES_PASSWORD=
+# REQUIRED for Tier 2. Change this before deploying.
+POSTGRES_PASSWORD=changeme
 
 # For local dev (non-Docker), uncomment:
 # PGHOST=localhost

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing. Context Library is a personal cogni
 
 ```bash
 npm run dev          # Start with hot reload (tsx watch)
-npm test             # Run full test suite (66 tests)
+npm test             # Run full test suite
 npm run build        # TypeScript compile
 ```
 
@@ -29,6 +29,14 @@ npm run test:watch   # Watch mode
 ```
 
 Tests use Vitest. The `dist/` directory is excluded from test discovery to prevent port conflicts.
+
+### PostgreSQL Tests
+
+Task-related tests (~29 tests) require a running PostgreSQL instance. Without Postgres, these tests are automatically skipped. To run the full suite:
+
+```bash
+docker run --rm -p 5432:5432 -e POSTGRES_DB=cl_test -e POSTGRES_USER=cl -e POSTGRES_PASSWORD=test pgvector/pgvector:pg16
+```
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ docker compose up -d
 
 **Available tools:** `store_handoff`, `get_latest_handoff`, `patch_handoff`
 
+> Handoff files are retained indefinitely by default. To enable automatic pruning of old handoffs, set `RETENTION_COUNT` to a positive number (e.g., `5000`).
+
 ### Tier 2: + PostgreSQL (Tasks + Full-Text Search)
 
 Adds structured task management with full-text search. Requires PostgreSQL 16 with pgvector.
@@ -226,6 +228,8 @@ If you see `Postgres migrations skipped — database not available`, the server 
 
 This server holds personal operational data — handoff state, tasks, execution logs. It is designed to run behind a reverse proxy that handles authentication. **Never expose the MCP server directly to the internet.**
 
+> **Note:** When using the auth proxy overlay (`docker-compose.auth.yml`), the MCP server still binds to `127.0.0.1:3100` from the base compose file. This means the unauthenticated server remains accessible on localhost. This is intentional for local debugging but should be considered in your deployment security model. A future release will address this in the overlay.
+
 For external access, use mcp-auth-proxy (included in the auth compose overlay) which handles OAuth 2.1 (DCR, authorization, token exchange) before forwarding authenticated requests to the server. Route external traffic through the proxy via Cloudflare Tunnel or your preferred reverse proxy.
 
 ## Environment Variables
@@ -239,7 +243,8 @@ See `.env.example` for all configuration options.
 | `SERVER_NAME` | `context-library` | MCP server name (visible to LLM clients as the tool namespace) |
 | `MCP_PORT` | `3100` | Server port |
 | `DATA_DIR` | `./data` | Handoff file storage path |
-| `RETENTION_COUNT` | `5000` | Max handoff files to retain |
+| `RETENTION_COUNT` | `0` | Max handoff files to retain (`0` = unlimited) |
+| `CORS_ORIGINS` | `https://claude.ai,https://claude.com` | Comma-separated list of allowed CORS origins |
 
 ### PostgreSQL (Tier 2)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,14 +46,16 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - Handoff schema versioning strategy for forward/backward compatibility
 - Migration tooling for schema changes across stored handoff files
 - Evaluate migrating append-only JSON handoffs to PostgreSQL events table
+- Migrate `z.any()` to `z.unknown()` in handoff schemas and tool parameter definitions for stricter type safety
 
 ### Artifact Storage
 - File/content storage with metadata, SHA-256 hashing, versioning
 - Prompt library via tagging convention on artifacts
 
 ### Integrations
-- Oura ring health data integration
+- Health/wearable data integration (e.g., Oura, Whoop, Apple Health)
 - Calendar/scheduling data feeds
 
 ### Infrastructure
 - CI/CD pipeline (GitHub Actions)
+- Refactor dynamic SQL assembly in search tools to a query builder pattern for maintainability

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -5,6 +5,8 @@
 
 services:
   mcp-auth-proxy:
+    # No ports published — requires a tunnel or reverse proxy for external access.
+    # See README for Cloudflare Tunnel example.
     image: ghcr.io/sigbit/mcp-auth-proxy:latest
     container_name: mcp-auth-proxy
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "context-library",
   "version": "0.5.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc && npm run copy-migrations",

--- a/src/__tests__/search-dedup.test.ts
+++ b/src/__tests__/search-dedup.test.ts
@@ -22,8 +22,8 @@ function makeRow(
 describe("search_context source deduplication", () => {
   it("collapses identical content to the oldest source_file", () => {
     const sharedText =
-      "The kid throwing star incident occurred on March 21 when a child brought a shuriken to school. " +
-      "This was reported by the teacher and escalated to administration. The parents were contacted immediately.";
+      "The database failover incident occurred on March 21 when the primary replica lost connectivity. " +
+      "This was detected by automated monitoring and escalated to the on-call engineer. The backup was promoted immediately.";
 
     const rows = [
       makeRow(sharedText, "2026-04-04T10-00-00-000Z-aaaa1111.json", { rrf_score: 0.035 }),
@@ -72,8 +72,8 @@ describe("search_context source deduplication", () => {
 
   it("over-fetch scenario: 15 duplicates + 5 unique collapses to 6", () => {
     const duplicateText =
-      "The throwing star incident was validated in the March 21 handoff. " +
-      "This event was significant because it required immediate escalation.";
+      "The database failover incident was documented in the March 21 handoff. " +
+      "This event was significant because it required immediate intervention.";
 
     const rows: any[] = [];
 
@@ -102,7 +102,7 @@ describe("search_context source deduplication", () => {
 
     // The surviving duplicate should be from March 01 (oldest)
     const dupSurvivor = deduped.find((r) =>
-      r.content_text.includes("throwing star incident was validated")
+      r.content_text.includes("database failover incident was documented")
     );
     expect(dupSurvivor).toBeDefined();
     expect(dupSurvivor!.metadata.source_file).toBe("2026-03-01T10-00-00-000Z-dup00000.json");

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -695,3 +695,37 @@ describe("MCP Tools", () => {
     });
   });
 });
+
+// ────────────────────────────────────────────────
+// Embedding unavailability tests
+// ────────────────────────────────────────────────
+
+describe("search_context — graceful degradation", () => {
+  it("returns EMBEDDING_UNAVAILABLE when embedding server is not running", async () => {
+    const res = await mcpPost(
+      jsonrpc("tools/call", {
+        name: "search_context",
+        arguments: { query: "test query" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = (await parseSseResponse(res)) as any;
+    const result = JSON.parse(data.result.content[0].text);
+    expect(result.error).toBe(true);
+    expect(result.code).toBe("EMBEDDING_UNAVAILABLE");
+  });
+
+  it("reindex returns EMBEDDING_UNAVAILABLE when embedding server is not running", async () => {
+    const res = await mcpPost(
+      jsonrpc("tools/call", {
+        name: "reindex",
+        arguments: {},
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = (await parseSseResponse(res)) as any;
+    const result = JSON.parse(data.result.content[0].text);
+    expect(result.error).toBe(true);
+    expect(result.code).toBe("EMBEDDING_UNAVAILABLE");
+  });
+});

--- a/src/__tests__/tasks.test.ts
+++ b/src/__tests__/tasks.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
  * Task tool integration tests.
  *
  * These tests require a running PostgreSQL instance. Set PG* env vars
- * or run: docker run --rm -p 5432:5432 -e POSTGRES_DB=cl_test -e POSTGRES_USER=cl -e POSTGRES_PASSWORD=test postgres:16-alpine
+ * or run: docker run --rm -p 5432:5432 -e POSTGRES_DB=cl_test -e POSTGRES_USER=cl -e POSTGRES_PASSWORD=test pgvector/pgvector:pg16
  *
  * If Postgres is not available, tests are skipped gracefully.
  */
@@ -99,7 +99,11 @@ async function checkPostgres(): Promise<boolean> {
 beforeAll(async () => {
   pgAvailable = await checkPostgres();
   if (!pgAvailable) {
-    console.warn("\u26a0\ufe0f  Postgres not available \u2014 task tests will be skipped");
+    console.log("\n" + "=".repeat(60));
+    console.log("  NOTICE: PostgreSQL not available");
+    console.log("  ~29 task tests will be SKIPPED");
+    console.log("  See CONTRIBUTING.md for setup instructions");
+    console.log("=".repeat(60) + "\n");
     return;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,15 @@
 import "dotenv/config";
 
+const defaultCorsOrigins = ["https://claude.ai", "https://claude.com"];
+
 export const config = {
   serverName: process.env.SERVER_NAME ?? "context-library",
   port: parseInt(process.env.MCP_PORT ?? "3100", 10),
   dataDir: process.env.DATA_DIR ?? "./data",
-  retentionCount: parseInt(process.env.RETENTION_COUNT ?? "5000", 10),
+  retentionCount: parseInt(process.env.RETENTION_COUNT ?? "0", 10),
+  corsOrigins: process.env.CORS_ORIGINS
+    ? process.env.CORS_ORIGINS.split(",").map((s) => s.trim())
+    : defaultCorsOrigins,
   embeddingUrl: process.env.EMBEDDING_URL ?? "http://embeddings:80",
   embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-ai/nomic-embed-text-v2-moe",
   embeddingDimensions: parseInt(process.env.EMBEDDING_DIMENSIONS ?? "768", 10),

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -7,7 +7,7 @@ export const pool = new Pool({
   connectionTimeoutMillis: 3_000, // fail fast when Postgres is unavailable
 });
 
-export async function query<T extends pg.QueryResultRow = any>(
+export async function query<T extends pg.QueryResultRow = Record<string, unknown>>(
   text: string,
   params?: unknown[]
 ): Promise<pg.QueryResult<T>> {

--- a/src/db/migrations/002_embeddings.sql
+++ b/src/db/migrations/002_embeddings.sql
@@ -1,7 +1,7 @@
 -- Enable pgvector
 CREATE EXTENSION IF NOT EXISTS vector;
 
--- Embeddings table — stores vector representations of any CB content type
+-- Embeddings table — stores vector representations of any content type
 CREATE TABLE IF NOT EXISTS embeddings (
     id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
     content_type    TEXT            NOT NULL,  -- 'handoff', 'task', 'document', 'transcript'

--- a/src/embeddings/client.ts
+++ b/src/embeddings/client.ts
@@ -1,5 +1,10 @@
 import { config } from "../config.js";
 
+interface EmbeddingResponseItem {
+  index: number;
+  embedding: number[];
+}
+
 /**
  * Generate embeddings via local TEI server.
  * TEI exposes an OpenAI-compatible /v1/embeddings endpoint.
@@ -26,6 +31,9 @@ export async function generateEmbedding(text: string): Promise<number[]> {
   }
 
   const data = await response.json();
+  if (!data?.data?.[0]?.embedding) {
+    throw new Error(`Unexpected embedding response: missing data.data[0].embedding`);
+  }
   return data.data[0].embedding;
 }
 
@@ -51,9 +59,12 @@ export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
   }
 
   const data = await response.json();
+  if (!Array.isArray(data?.data) || data.data.length === 0) {
+    throw new Error(`Unexpected embedding response: missing or empty data.data array`);
+  }
   return data.data
-    .sort((a: any, b: any) => a.index - b.index)
-    .map((d: any) => d.embedding);
+    .sort((a: EmbeddingResponseItem, b: EmbeddingResponseItem) => a.index - b.index)
+    .map((d: EmbeddingResponseItem) => d.embedding);
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serve } from "@hono/node-server";
@@ -10,7 +11,10 @@ import { registerSearchTools } from "./tools/search.js";
 import { ensureDataDir } from "./storage/json-store.js";
 import { runMigrations } from "./db/migrate.js";
 import { pool } from "./db/client.js";
-import { stat } from "node:fs/promises";
+import { access, constants } from "node:fs/promises";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
 
 const app = new Hono();
 
@@ -18,7 +22,7 @@ const app = new Hono();
 app.use(
   "/*",
   cors({
-    origin: ["https://claude.ai", "https://claude.com"],
+    origin: config.corsOrigins,
     allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization", "mcp-session-id"],
     exposeHeaders: ["WWW-Authenticate", "mcp-session-id"],
@@ -37,7 +41,7 @@ app.use("/*", async (c, next) => {
 app.get("/health", (c) =>
   c.json({
     status: "ok",
-    version: "0.5.0",
+    version,
     uptime: Math.floor(process.uptime()),
   })
 );
@@ -46,7 +50,7 @@ app.get("/health", (c) =>
 app.get("/health/ready", async (c) => {
   let archiveWritable = false;
   try {
-    await stat(config.dataDir);
+    await access(config.dataDir, constants.W_OK);
     archiveWritable = true;
   } catch {
     archiveWritable = false;
@@ -63,7 +67,7 @@ app.get("/health/ready", async (c) => {
 function createMcpServer(): McpServer {
   const server = new McpServer({
     name: config.serverName,
-    version: "0.5.0",
+    version,
   });
   registerHandoffTools(server);
   registerTaskTools(server);
@@ -117,6 +121,8 @@ app.delete("/mcp", async (c) => {
 });
 
 // Initialize and start
+let httpServer: ReturnType<typeof serve>;
+
 async function main() {
   await ensureDataDir();
   try {
@@ -128,7 +134,7 @@ async function main() {
     );
   }
 
-  serve(
+  httpServer = serve(
     {
       fetch: app.fetch,
       port: config.port,
@@ -142,9 +148,10 @@ async function main() {
   );
 }
 
-// Graceful shutdown — drain pg pool on container stop
+// Graceful shutdown — close HTTP server and drain pg pool on container stop
 async function shutdown(signal: string) {
   console.log(`[shutdown] ${signal} received, draining...`);
+  httpServer?.close();
   await pool.end();
   process.exit(0);
 }

--- a/src/storage/json-store.ts
+++ b/src/storage/json-store.ts
@@ -110,6 +110,8 @@ export async function getHandoffCount(): Promise<number> {
  * Filenames sort chronologically by ISO timestamp prefix.
  */
 async function pruneHandoffs(handoffsDir: string, retentionCount: number): Promise<void> {
+  if (retentionCount <= 0) return; // 0 = unlimited retention
+
   const entries = (await readdir(handoffsDir))
     .filter((f) => f.endsWith(".json") && !f.startsWith(".tmp-"))
     .sort();

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -24,13 +24,22 @@ function sourceFileTimestamp(sourceFile: string): string {
   return match ? match[1] : "9999"; // unknown files sort last
 }
 
+interface SearchResultRow {
+  content_type: string;
+  content_id: string;
+  content_text: string;
+  metadata: Record<string, unknown>;
+  similarity?: number;
+  rrf_score?: number;
+}
+
 /**
  * Deduplicate search results by content fingerprint, keeping the oldest source_file.
  * Returns { deduped, preDedupCount }.
  */
-export function deduplicateResults(rows: any[]): { deduped: any[]; preDedupCount: number } {
+export function deduplicateResults(rows: SearchResultRow[]): { deduped: SearchResultRow[]; preDedupCount: number } {
   const preDedupCount = rows.length;
-  const groups = new Map<string, any[]>();
+  const groups = new Map<string, SearchResultRow[]>();
 
   for (const row of rows) {
     const fp = contentFingerprint(row.content_text ?? "");
@@ -40,15 +49,15 @@ export function deduplicateResults(rows: any[]): { deduped: any[]; preDedupCount
     groups.get(fp)!.push(row);
   }
 
-  const deduped: any[] = [];
+  const deduped: SearchResultRow[] = [];
   for (const group of groups.values()) {
     if (group.length === 1) {
       deduped.push(group[0]);
     } else {
       // Keep the row with the oldest source_file
       group.sort((a, b) => {
-        const aFile = a.metadata?.source_file ?? "";
-        const bFile = b.metadata?.source_file ?? "";
+        const aFile = (a.metadata?.source_file as string) ?? "";
+        const bFile = (b.metadata?.source_file as string) ?? "";
         if (!aFile && !bFile) return 0;
         if (!aFile) return -1; // no source_file = keep first encountered
         if (!bFile) return 1;
@@ -61,7 +70,7 @@ export function deduplicateResults(rows: any[]): { deduped: any[]; preDedupCount
   return { deduped, preDedupCount };
 }
 
-const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content \u2014 handoff history, tasks, and documents. Returns results ranked by meaning similarity, not keyword match.
+const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content — handoff history, tasks, and documents. Returns results ranked by meaning similarity, not keyword match.
 
 Use this when the user asks about past decisions, previous conversations, historical context, or when full-text search (search_tasks) might miss results because exact words don't match.
 
@@ -74,7 +83,7 @@ Parameters:
 
 Returns: Array of {content_type, content_id, content_text (truncated), metadata, similarity}
 
-Retrieval guidance: If results appear to reference an event, decision, or incident indirectly (e.g., \"the throwing star incident was validated\" rather than describing what actually happened), the original source may exist deeper in the index. Reformulate your query with more specific contextual terms (names, locations, actions) and search again with a lower similarity_threshold (try 0.05) and higher limit (try 20). Prefer results from the oldest source_file \u2014 the filename timestamp indicates when the content was originally captured.`;
+Retrieval guidance: If results appear to reference an event, decision, or incident indirectly (e.g., "the deployment issue was resolved" rather than describing what actually happened), the original source may exist deeper in the index. Reformulate your query with more specific contextual terms (names, locations, actions) and search again with a lower similarity_threshold (try 0.05) and higher limit (try 20). Prefer results from the oldest source_file — the filename timestamp indicates when the content was originally captured.`;
 
 const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs and tasks. Use after bulk data changes or when search results seem stale.
 
@@ -213,18 +222,22 @@ export function registerSearchTools(mcpServer: McpServer): void {
         }
 
         // Deduplicate: collapse near-identical content to oldest source
-        const { deduped, preDedupCount } = deduplicateResults(result.rows);
+        const { deduped, preDedupCount } = deduplicateResults(result.rows as unknown as SearchResultRow[]);
 
         // Re-sort by original ranking and truncate to requested limit
         const sortKey = useHybrid ? "rrf_score" : "similarity";
-        deduped.sort((a: any, b: any) => (b[sortKey] ?? 0) - (a[sortKey] ?? 0));
+        deduped.sort((a, b) => {
+          const aVal = sortKey === "rrf_score" ? (a.rrf_score ?? 0) : (a.similarity ?? 0);
+          const bVal = sortKey === "rrf_score" ? (b.rrf_score ?? 0) : (b.similarity ?? 0);
+          return bVal - aVal;
+        });
         const finalRows = deduped.slice(0, limit);
 
         return {
           content: [{
             type: "text" as const,
             text: JSON.stringify({
-              results: finalRows.map((r: any) => ({
+              results: finalRows.map((r: SearchResultRow) => ({
                 content_type: r.content_type,
                 content_id: r.content_id,
                 content_text: r.content_text,


### PR DESCRIPTION
Address 20 findings from the open-source release audit:

- Add .dockerignore to exclude secrets and build artifacts from images
- Make CORS origins configurable via CORS_ORIGINS env var
- Import version from package.json instead of hardcoding
- Fix health readiness check to test writability (access W_OK vs stat)
- Close HTTP server in shutdown handler before draining pg pool
- Add null-safety validation on embedding API responses
- Replace `any` types with SearchResultRow, EmbeddingResponseItem interfaces
- Default RETENTION_COUNT to 0 (unlimited) with early-return guard
- Add engines field requiring Node >=22
- Remove personal test data ("throwing star") and "CB" references
- Add embedding unavailability tests for search_context and reindex
- Add CONTRIBUTING.md with PostgreSQL test setup instructions
- Improve Postgres test skip visibility with banner notice
- Add security note about localhost:3100 with auth overlay to README
- Add ROADMAP entries for z.unknown migration, SQL builder, wearables
- Set default POSTGRES_PASSWORD=changeme in .env.example