### PR TITLE
feat: add TEI compose profiles for GPU and CPU deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ POSTGRES_PASSWORD=changeme
 # PGDATABASE=context_library
 
 # ── Tier 3: Embeddings (Semantic Search) ───────────────
+#
+# Embedding server profile — choose one when starting:
+#   GPU:  docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-gpu up -d
+#   CPU:  docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-cpu up -d
+#
+# With no --profile flag, neither TEI service starts (graceful degradation).
+# Apple Silicon: run TEI natively via Homebrew and set EMBEDDING_URL to host.docker.internal.
 
 EMBEDDING_URL=http://embeddings:80
 EMBEDDING_MODEL=nomic-ai/nomic-embed-text-v2-moe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Migrations live in `src/db/migrations/` as numbered `.sql` files. The runner (`s
 **Compose stacking** (additive overlays):
 - `docker-compose.yml` — Base: context-library container, binds `127.0.0.1:3100`, mounts `./data`.
 - `docker-compose.postgres.yml` — Adds Postgres (pgvector/pgvector:pg16), healthcheck, PG* env vars injected into context-library. Data at `./data/postgres`.
-- `docker-compose.embeddings.yml` — Adds TEI container (CUDA by default), GPU reservation, healthcheck. Set `EMBEDDING_URL`.
+- `docker-compose.embeddings.yml` — Adds TEI container via `--profile` flag: `embeddings-gpu` (CUDA/NVIDIA) or `embeddings-cpu` (no GPU). Both profiles use network alias `embeddings` so `EMBEDDING_URL` stays the same. With no profile, neither TEI service starts.
 - `docker-compose.auth.yml` — Adds mcp-auth-proxy for OAuth 2.1. No ports published (needs tunnel). Mounts `./proxy-data` and `./proxy-certs`.
 
 **Postgres Dockerfile** (`postgres.Dockerfile`): Single line — `FROM pgvector/pgvector:pg16`. Referenced by `docker-compose.postgres.yml`.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,19 @@ docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
 
 ### Tier 3: + Embeddings (Semantic Search)
 
-Adds vector-based semantic search across all stored content using a Text Embeddings Inference (TEI) server.
+Adds vector-based semantic search across all stored content using a Text Embeddings Inference (TEI) server. Use the `--profile` flag to select GPU or CPU runtime.
 
+**GPU (desktop with NVIDIA GPU):**
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-gpu up -d
 ```
+
+**CPU (NAS or any machine without GPU):**
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-cpu up -d
+```
+
+With no `--profile` flag, neither TEI service starts — the application degrades gracefully (semantic search falls back to FTS).
 
 **Additional tools:** `search_context`, `reindex`
 
@@ -48,10 +56,10 @@ The TEI server can run on a separate machine — just point `EMBEDDING_URL` to i
 
 #### Embedding Server Platform Options
 
-| Platform | Method | GPU Acceleration |
+| Platform | Profile / Method | GPU Acceleration |
 |---|---|---|
-| **Linux/Windows (NVIDIA GPU)** | Docker: `ghcr.io/huggingface/text-embeddings-inference:cuda-1.9` | CUDA (compute capability 7.5+) |
-| **Linux/Windows (no GPU)** | Docker: `ghcr.io/huggingface/text-embeddings-inference:cpu-1.9` | None (CPU only, slower) |
+| **Linux/Windows (NVIDIA GPU)** | `--profile embeddings-gpu` | CUDA (compute capability 7.5+) |
+| **Linux/Windows (no GPU)** | `--profile embeddings-cpu` | None (CPU only, slower) |
 | **macOS Apple Silicon** | Native: `brew install huggingface/tap/tei` | Metal (via native binary only) |
 
 > **Apple Silicon note:** macOS does not support GPU passthrough into Docker containers. Running TEI in Docker on M-series Macs will be CPU-bound and slow. For GPU acceleration, install TEI natively via Homebrew and run it outside of Docker:

--- a/docker-compose.embeddings.yml
+++ b/docker-compose.embeddings.yml
@@ -1,24 +1,47 @@
 # Embedding server for semantic search (Tier 3)
 #
+# Uses Docker Compose profiles to select GPU or CPU runtime.
+# Only one profile can be active at a time (both services share
+# the same container_name, so Compose will refuse to start both).
+#
+# Start with:
+#   GPU:  docker compose ... -f docker-compose.embeddings.yml --profile embeddings-gpu up -d
+#   CPU:  docker compose ... -f docker-compose.embeddings.yml --profile embeddings-cpu up -d
+#
+# With no --profile flag, neither TEI service starts — the application
+# degrades gracefully (semantic search falls back to FTS).
+#
 # Platform options:
-#   NVIDIA GPU:  image: ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 (default below)
-#   CPU only:    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9
-#                (remove the deploy.resources section if using CPU image)
+#   NVIDIA GPU:    Use --profile embeddings-gpu (default for desktop with CUDA GPU)
+#   CPU only:      Use --profile embeddings-cpu (for NAS or machines without GPU)
 #   Apple Silicon: Run TEI natively via Homebrew (brew install huggingface/tap/tei)
 #                  Start with: text-embeddings-router --model-id nomic-ai/nomic-embed-text-v2-moe --port 8090
 #                  Then set EMBEDDING_URL=http://host.docker.internal:8090 in .env
-#                  and remove/comment out the embeddings service below.
+#                  and omit this compose file entirely.
 #
 # The embedding server can also run on a separate machine. Set EMBEDDING_URL accordingly.
+#
+# Note: depends_on is not used here because Compose does not support
+# cross-profile depends_on (the inactive profile's service is treated
+# as undefined). The application handles this via graceful degradation —
+# isEmbeddingAvailable() checks TEI health before every operation.
+# The healthcheck + restart: always policy ensures TEI recovers without
+# Compose-level startup ordering.
 
 services:
-  embeddings:
+  # ── GPU profile (NVIDIA CUDA) ──────────────────────────
+  embeddings-gpu:
     image: ghcr.io/huggingface/text-embeddings-inference:cuda-1.9
     container_name: context-library-embeddings
-    restart: unless-stopped
+    profiles: [embeddings-gpu]
+    restart: always
     command: --model-id ${EMBEDDING_MODEL:-nomic-ai/nomic-embed-text-v2-moe} --port 80
     volumes:
       - ./data/models:/data
+    networks:
+      default:
+        aliases:
+          - embeddings
     deploy:
       resources:
         reservations:
@@ -32,9 +55,28 @@ services:
       timeout: 10s
       retries: 5
 
+  # ── CPU profile (no GPU required) ──────────────────────
+  embeddings-cpu:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9
+    container_name: context-library-embeddings
+    profiles: [embeddings-cpu]
+    restart: always
+    command: --model-id ${EMBEDDING_MODEL:-nomic-ai/nomic-embed-text-v2-moe} --port 80
+    volumes:
+      - ./data/models:/data
+    networks:
+      default:
+        aliases:
+          - embeddings
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  # ── Context Library overlay ────────────────────────────
+  # Both services use network alias "embeddings", so EMBEDDING_URL
+  # works identically regardless of which profile is active.
   context-library:
     environment:
       - EMBEDDING_URL=http://embeddings:80
-    depends_on:
-      embeddings:
-        condition: service_healthy


### PR DESCRIPTION
## Summary

- Replace single GPU-only TEI service with two profiled services (`embeddings-gpu`, `embeddings-cpu`) using Docker Compose profiles
- Same compose file now works on both desktop (NVIDIA GPU) and NAS (CPU-only) machines
- Both profiles use network alias `embeddings` so `EMBEDDING_URL` stays `http://embeddings:80` regardless of active profile
- With no `--profile` flag, neither TEI service starts — graceful degradation to FTS
- Restart policy upgraded from `unless-stopped` to `always` for better process-level recovery
- Updated `.env.example`, `README.md`, and `CLAUDE.md` with profile documentation

## Usage

```bash
# GPU (desktop with NVIDIA)
docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-gpu up -d

# CPU (NAS or no GPU)
docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.embeddings.yml --profile embeddings-cpu up -d
```

## Design note

`depends_on` with `service_healthy` is not used because Docker Compose does not support cross-profile `depends_on` — referencing an inactive profile's service causes an "undefined service" validation error. The application already handles this via `isEmbeddingAvailable()` health checks before every embedding operation, and TEI's own healthcheck + `restart: always` policy ensures recovery without Compose-level startup ordering.

## Test plan

- [x] `docker compose config --profile embeddings-gpu` — valid config with CUDA image and NVIDIA device reservation
- [x] `docker compose config --profile embeddings-cpu` — valid config with CPU image, no GPU resources
- [x] `docker compose config` (no profile) — no TEI services in output
- [x] Full stack: `docker compose -f ... --profile embeddings-gpu -f docker-compose.auth.yml config` — all services present

🤖 Generated with [Claude Code](https://claude.com/claude-code)