### PR TITLE
ci: add CI/CD pipeline with Snyk gates and GHCR publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test
+
+      - name: Snyk dependency scan
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # --- CI gates (same as ci.yml) ---
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test
+
+      - name: Snyk dependency scan
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high
+
+      # --- Docker build + container scan + publish ---
+      - name: Extract version from tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -t ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }} \
+            -t ghcr.io/onideus/context-library:latest \
+            .
+
+      - name: Snyk container scan
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
+          args: --severity-threshold=high
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
+          docker push ghcr.io/onideus/context-library:latest

--- a/README.md
+++ b/README.md
@@ -285,6 +285,89 @@ docker compose \
 
 > **Note:** When using `TUNNEL_TOKEN`, the tunnel configuration is managed in the Cloudflare dashboard, not in a local config file. The dashboard config takes precedence. Point the tunnel's public hostname to `https://mcp-auth-proxy:443`.
 
+## Release Workflow
+
+Every tagged release follows a gated pipeline: **Tag → CI → Snyk dep scan → Docker build → Snyk container scan → GHCR publish**. Images only reach the registry if all gates pass.
+
+**To cut a release:**
+
+```bash
+git tag v0.5.1
+git push origin v0.5.1
+```
+
+Tag format is `vX.Y.Z` (semver with `v` prefix). The release workflow:
+
+1. Runs the full CI suite (install, build, test)
+2. Scans dependencies with Snyk (hard gate — high/critical vulns block the release)
+3. Builds the Docker image from the multi-stage `Dockerfile`
+4. Scans the container image with Snyk (hard gate)
+5. Pushes to `ghcr.io/onideus/context-library:<version>` and `ghcr.io/onideus/context-library:latest`
+
+The version tag is stripped of the `v` prefix for the image tag (e.g., tag `v0.5.1` publishes image `0.5.1`).
+
+PRs and pushes to `main` run the CI workflow (steps 1-2 above) without building or publishing images.
+
+## Pulling Without Cloning
+
+You can run Context Library directly from the published GHCR image without cloning the repository:
+
+```bash
+# Create a minimal docker-compose.yml
+cat > docker-compose.yml << 'EOF'
+services:
+  context-library:
+    image: ghcr.io/onideus/context-library:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - ./data:/app/data
+    env_file:
+      - .env
+EOF
+
+# Create a .env file (see .env.example in the repo for all options)
+echo "SERVER_NAME=context-library" > .env
+
+# Start
+docker compose up -d
+```
+
+For Tier 2 (Postgres) or Tier 3 (embeddings), download the additional compose files from the repo and stack them as described in [Deployment Tiers](#deployment-tiers).
+
+## Snyk Setup (Maintainer)
+
+The CI and release pipelines require a `SNYK_TOKEN` repository secret for dependency and container vulnerability scanning.
+
+**Setup:**
+
+1. Sign up for a free Snyk account at [snyk.io](https://snyk.io) (free tier covers open-source projects)
+2. Generate an API token from **Account Settings → API Token**
+3. Add it as a repository secret:
+   ```bash
+   gh secret set SNYK_TOKEN --repo onideus/context-library
+   ```
+
+The scan threshold is `high` — only high and critical severity vulnerabilities block the pipeline. Medium and low findings are reported but do not fail the build.
+
+## Maintainer Notes
+
+### Branch Protection
+
+After the CI workflow is live, enable branch protection for `main` to require the `ci` job to pass before merging:
+
+```bash
+gh api -X PUT /repos/onideus/context-library/branches/main/protection \
+  -f required_status_checks.strict=true \
+  -F required_status_checks.contexts[]='ci' \
+  -F enforce_admins=false \
+  -F required_pull_request_reviews.required_approving_review_count=0 \
+  -F restrictions=null
+```
+
+This requires the `ci` job (from `.github/workflows/ci.yml`) to pass on all PRs before they can be merged to `main`.
+
 ## Troubleshooting
 
 **`EACCES: permission denied` when writing handoffs**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   context-library:
-    build: .
+    # build: .  # Uncomment for local builds, comment out 'image:' below
+    image: ghcr.io/onideus/context-library:latest
     container_name: context-library
     restart: unless-stopped
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "tsx": "^4.19.3",
         "typescript": "^5.7.3",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2254,9 +2257,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "pg": "^8.20.0",
     "zod": "^3.25.0"
   },
+  "overrides": {
+    "path-to-regexp": "8.4.0"
+  },
   "devDependencies": {
     "@types/node": "^22.13.4",
     "@types/pg": "^8.20.0",


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/ci.yml`): Runs on every PR and push to `main`. Steps: checkout → Node 22 setup → `npm ci` → `npm run build` → `npm test` → Snyk dependency scan (`--severity-threshold=high`, hard gate).
- **Release workflow** (`.github/workflows/release.yml`): Runs on `v*` tags. Repeats all CI steps, then builds the Docker image, runs Snyk container scan (hard gate), and pushes to GHCR (`ghcr.io/onideus/context-library:<version>` + `:latest`).
- **docker-compose.yml**: Switched from `build: .` to `image: ghcr.io/onideus/context-library:latest`. Commented `build:` line preserved for local dev override.
- **README**: Added Release Workflow, Pulling Without Cloning, Snyk Setup, and Maintainer Notes (branch protection) sections.

## Design choice: inline vs composite action

CI steps are duplicated inline in `release.yml` rather than extracted into a composite action. Rationale: the CI steps are 6 lines of config — a composite action would add a third file, an `action.yml` manifest, and indirection for minimal DRY benefit. If the CI steps grow significantly, extracting to a composite action becomes worthwhile.

## All Actions pinned to SHA

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `snyk/actions/node` | `9adf32b1121593767fc3c057af55b55db032dc04` | v1.0.0 |
| `snyk/actions/docker` | `9adf32b1121593767fc3c057af55b55db032dc04` | v1.0.0 |

## Branch protection command (copy-paste after merge)

```bash
gh api -X PUT /repos/onideus/context-library/branches/main/protection \
  -f required_status_checks.strict=true \
  -F required_status_checks.contexts[]='ci' \
  -F enforce_admins=false \
  -F required_pull_request_reviews.required_approving_review_count=0 \
  -F restrictions=null
```

The `contexts[]='ci'` matches the job name in `.github/workflows/ci.yml`.

## Test plan

- [ ] CI workflow runs on this PR (will need `SNYK_TOKEN` secret to fully pass)
- [ ] Verify workflow YAML is valid (GitHub will report syntax errors on push)
- [ ] After merge: tag `v0.5.0` to test the full release pipeline end-to-end
- [ ] Verify GHCR image is published and pullable

## References

Task ID: `6a5076aa-4231-4a12-bcb8-78c58d76fdfe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)