### PR TITLE
feat: JIT context envelope for entity-aware search (v0.5.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs/
 proxy-certs/
 proxy-data/
 .claude/worktrees/
+entities.seed.json

--- a/entities.seed.example.json
+++ b/entities.seed.example.json
@@ -1,0 +1,26 @@
+[
+  {
+    "canonical_name": "Work Laptop",
+    "scope": "work",
+    "aliases": ["company laptop", "dev machine", "office laptop"],
+    "constraints": ["Company-owned device", "No unapproved software installations"]
+  },
+  {
+    "canonical_name": "Home Server",
+    "scope": "personal",
+    "aliases": ["NAS", "home NAS", "media server"],
+    "constraints": []
+  },
+  {
+    "canonical_name": "Dev Desktop",
+    "scope": "shared",
+    "aliases": ["development workstation", "desktop"],
+    "constraints": ["Shared device — check scope before recommending changes"]
+  },
+  {
+    "canonical_name": "Project Alpha",
+    "scope": "work",
+    "aliases": ["alpha", "project-alpha"],
+    "constraints": ["Confidential — do not reference in personal contexts"]
+  }
+]

--- a/src/__tests__/entities.test.ts
+++ b/src/__tests__/entities.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEnvelope,
+  emptyEnvelope,
+  generateBoundaryNotice,
+  type EntityInfo,
+} from "../tools/entities.js";
+
+// ── Test fixtures (generic names only — no personal data) ─────────
+
+const workLaptop: EntityInfo = {
+  canonical_name: "Work Laptop",
+  scope: "work",
+  aliases: ["company laptop", "dev machine"],
+  constraints: ["Company-owned device", "No unapproved software"],
+};
+
+const homeServer: EntityInfo = {
+  canonical_name: "Home Server",
+  scope: "personal",
+  aliases: ["NAS", "media server"],
+  constraints: [],
+};
+
+const devDesktop: EntityInfo = {
+  canonical_name: "Dev Desktop",
+  scope: "shared",
+  aliases: ["workstation"],
+  constraints: ["Shared device — check scope before recommending changes"],
+};
+
+const projectAlpha: EntityInfo = {
+  canonical_name: "Project Alpha",
+  scope: "work",
+  aliases: ["alpha"],
+  constraints: ["Confidential — do not reference in personal contexts"],
+};
+
+// ── emptyEnvelope ─────────────────────────────────────────────────
+
+describe("emptyEnvelope", () => {
+  it("returns default empty structure", () => {
+    const env = emptyEnvelope();
+    expect(env.scope_flags).toEqual([]);
+    expect(env.boundary_detected).toBe(false);
+    expect(env.constraint_alerts).toEqual([]);
+    expect(env.entity_map).toEqual({});
+    expect(env.active_constraints).toEqual([]);
+  });
+});
+
+// ── computeEnvelope ───────────────────────────────────────────────
+
+describe("computeEnvelope", () => {
+  it("returns empty envelope when no entities match", () => {
+    const env = computeEnvelope([]);
+    expect(env).toEqual(emptyEnvelope());
+  });
+
+  it("sets correct scope for work-only entities", () => {
+    const env = computeEnvelope([workLaptop]);
+    expect(env.scope_flags).toEqual(["work"]);
+    expect(env.boundary_detected).toBe(false);
+    expect(env.entity_map["Work Laptop"]).toBeDefined();
+    expect(env.constraint_alerts).toContain("Work Laptop: Company-owned device");
+    expect(env.constraint_alerts).toContain("Work Laptop: No unapproved software");
+    expect(env.active_constraints).toHaveLength(2);
+  });
+
+  it("sets correct scope for personal-only entities", () => {
+    const env = computeEnvelope([homeServer]);
+    expect(env.scope_flags).toEqual(["personal"]);
+    expect(env.boundary_detected).toBe(false);
+    expect(env.constraint_alerts).toEqual([]);
+    expect(env.active_constraints).toEqual([]);
+  });
+
+  it("detects boundary when results span work and personal scopes", () => {
+    const env = computeEnvelope([workLaptop, homeServer]);
+    expect(env.scope_flags).toContain("work");
+    expect(env.scope_flags).toContain("personal");
+    expect(env.boundary_detected).toBe(true);
+  });
+
+  it("detects boundary with shared + work scopes", () => {
+    const env = computeEnvelope([workLaptop, devDesktop]);
+    expect(env.scope_flags).toContain("work");
+    expect(env.scope_flags).toContain("shared");
+    expect(env.boundary_detected).toBe(true);
+  });
+
+  it("does not false-positive on multiple entities in same scope", () => {
+    const env = computeEnvelope([workLaptop, projectAlpha]);
+    expect(env.scope_flags).toEqual(["work"]);
+    expect(env.boundary_detected).toBe(false);
+    expect(env.entity_map["Work Laptop"]).toBeDefined();
+    expect(env.entity_map["Project Alpha"]).toBeDefined();
+  });
+
+  it("collects all constraints from multiple entities", () => {
+    const env = computeEnvelope([workLaptop, projectAlpha]);
+    expect(env.active_constraints).toHaveLength(3);
+    expect(env.constraint_alerts).toHaveLength(3);
+  });
+
+  it("scope_flags are sorted alphabetically", () => {
+    const env = computeEnvelope([homeServer, workLaptop, devDesktop]);
+    expect(env.scope_flags).toEqual(["personal", "shared", "work"]);
+  });
+});
+
+// ── generateBoundaryNotice ────────────────────────────────────────
+
+describe("generateBoundaryNotice", () => {
+  it("returns null when no boundary detected", () => {
+    const env = computeEnvelope([workLaptop]);
+    expect(generateBoundaryNotice(env)).toBeNull();
+  });
+
+  it("returns null for empty envelope", () => {
+    expect(generateBoundaryNotice(emptyEnvelope())).toBeNull();
+  });
+
+  it("generates notice when boundary is detected", () => {
+    const env = computeEnvelope([workLaptop, homeServer]);
+    const notice = generateBoundaryNotice(env);
+    expect(notice).not.toBeNull();
+    expect(notice).toContain("BOUNDARY NOTICE");
+    expect(notice).toContain("personal");
+    expect(notice).toContain("work");
+    expect(notice).toContain("DO NOT blend recommendations across scopes");
+  });
+
+  it("includes constraints grouped by scope", () => {
+    const env = computeEnvelope([workLaptop, homeServer]);
+    const notice = generateBoundaryNotice(env)!;
+    expect(notice).toContain("work scope");
+    expect(notice).toContain("Company-owned device");
+  });
+
+  it("handles scopes with no constraints gracefully", () => {
+    // homeServer has no constraints, should not crash or show empty constraint line
+    const env = computeEnvelope([workLaptop, homeServer]);
+    const notice = generateBoundaryNotice(env)!;
+    // personal scope has no constraints — should not appear as "Constraints from personal scope:"
+    expect(notice).not.toContain("Constraints from personal scope:");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,4 +13,5 @@ export const config = {
   embeddingUrl: process.env.EMBEDDING_URL ?? "http://embeddings:80",
   embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-ai/nomic-embed-text-v2-moe",
   embeddingDimensions: parseInt(process.env.EMBEDDING_DIMENSIONS ?? "768", 10),
+  entitySeedPath: process.env.ENTITY_SEED_PATH ?? "./data/entities.seed.json",
 } as const;

--- a/src/db/migrations/003_entities.sql
+++ b/src/db/migrations/003_entities.sql
@@ -1,0 +1,33 @@
+-- Entity table for JIT context envelope (v0.5.1)
+-- Stores canonical entities with scope, aliases, and constraints.
+-- Schema only — actual entity data loads from deployment-local seed files.
+
+CREATE TABLE IF NOT EXISTS entities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_name TEXT NOT NULL UNIQUE,
+  scope TEXT NOT NULL CHECK (scope IN ('work', 'personal', 'shared')),
+  aliases TEXT[] DEFAULT '{}',
+  constraints TEXT[] DEFAULT '{}',
+  metadata JSONB DEFAULT '{}',
+  last_referenced TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_entities_scope ON entities(scope);
+CREATE INDEX idx_entities_canonical ON entities(canonical_name);
+CREATE INDEX idx_entities_aliases ON entities USING GIN(aliases);
+
+-- Auto-update updated_at trigger (same pattern as tasks table)
+CREATE OR REPLACE FUNCTION update_entities_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_entities_updated_at
+  BEFORE UPDATE ON entities
+  FOR EACH ROW
+  EXECUTE FUNCTION update_entities_updated_at();

--- a/src/db/seed-entities.ts
+++ b/src/db/seed-entities.ts
@@ -1,0 +1,97 @@
+/**
+ * Entity seed loader: Reads entities from a JSON file and upserts into the entities table.
+ *
+ * Design:
+ * - Idempotent: ON CONFLICT (canonical_name) DO UPDATE — safe to re-run as new entities are added.
+ * - Skips silently if seed file is missing (graceful degradation for deployments without entities).
+ * - Skips silently if Postgres is unavailable (Tier 1 JSON-only mode).
+ *
+ * The seed file path is configurable via ENTITY_SEED_PATH env var (default: ./data/entities.seed.json).
+ * See entities.seed.example.json in the repo root for the expected format.
+ */
+
+import { readFile } from "node:fs/promises";
+import { config } from "../config.js";
+
+interface SeedEntity {
+  canonical_name: string;
+  scope: "work" | "personal" | "shared";
+  aliases?: string[];
+  constraints?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export async function seedEntities(): Promise<void> {
+  const seedPath = config.entitySeedPath;
+
+  // Read seed file — skip silently if missing
+  let raw: string;
+  try {
+    raw = await readFile(seedPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // File doesn't exist — expected in many deployments
+      return;
+    }
+    console.warn("[seed-entities] Failed to read seed file:", (err as Error).message);
+    return;
+  }
+
+  let entities: SeedEntity[];
+  try {
+    entities = JSON.parse(raw);
+    if (!Array.isArray(entities)) {
+      console.warn("[seed-entities] Seed file is not a JSON array, skipping");
+      return;
+    }
+  } catch (err) {
+    console.warn("[seed-entities] Invalid JSON in seed file:", (err as Error).message);
+    return;
+  }
+
+  if (entities.length === 0) return;
+
+  // Lazy import to avoid module-level Postgres dependency
+  let queryFn: (text: string, params?: unknown[]) => Promise<unknown>;
+  try {
+    const { query } = await import("./client.js");
+    queryFn = query;
+  } catch (err) {
+    console.warn("[seed-entities] Database not available, skipping entity seed:", (err as Error).message);
+    return;
+  }
+
+  let upserted = 0;
+  for (const entity of entities) {
+    if (!entity.canonical_name || !entity.scope) {
+      console.warn(`[seed-entities] Skipping invalid entity (missing canonical_name or scope)`);
+      continue;
+    }
+
+    try {
+      await queryFn(
+        `INSERT INTO entities (canonical_name, scope, aliases, constraints, metadata)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (canonical_name) DO UPDATE SET
+           scope = EXCLUDED.scope,
+           aliases = EXCLUDED.aliases,
+           constraints = EXCLUDED.constraints,
+           metadata = EXCLUDED.metadata`,
+        [
+          entity.canonical_name,
+          entity.scope,
+          entity.aliases ?? [],
+          entity.constraints ?? [],
+          entity.metadata ?? {},
+        ]
+      );
+      upserted++;
+    } catch (err) {
+      console.warn(`[seed-entities] Failed to upsert "${entity.canonical_name}":`, (err as Error).message);
+    }
+  }
+
+  if (upserted > 0) {
+    console.log(`[seed-entities] Upserted ${upserted} entities from ${seedPath}`);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -143,6 +143,14 @@ async function main() {
     );
   }
 
+  // Seed entities from deployment-local file (graceful — skips if file or DB missing)
+  try {
+    const { seedEntities } = await import("./db/seed-entities.js");
+    await seedEntities();
+  } catch (err) {
+    console.warn("[startup] Entity seeding skipped:", (err as Error).message);
+  }
+
   httpServer = serve(
     {
       fetch: app.fetch,

--- a/src/tools/entities.ts
+++ b/src/tools/entities.ts
@@ -1,0 +1,168 @@
+/**
+ * Entity lookup and context envelope computation for JIT context (v0.5.1).
+ *
+ * Design constraints:
+ * - No module-level DB import — uses lazy dynamic import for graceful degradation.
+ * - computeEnvelope is a pure function (testable without DB).
+ * - Entity matching is case-insensitive against canonical_name and aliases.
+ */
+
+// ── Types ────────────────────────────────────────────────────────
+
+export interface EntityInfo {
+  canonical_name: string;
+  scope: "work" | "personal" | "shared";
+  aliases: string[];
+  constraints: string[];
+}
+
+export interface ContextEnvelope {
+  scope_flags: string[];
+  boundary_detected: boolean;
+  constraint_alerts: string[];
+  entity_map: Record<string, EntityInfo>;
+  active_constraints: string[];
+}
+
+interface EntityRow {
+  canonical_name: string;
+  scope: string;
+  aliases: string[];
+  constraints: string[];
+}
+
+// ── Empty Envelope ───────────────────────────────────────────────
+
+export function emptyEnvelope(): ContextEnvelope {
+  return {
+    scope_flags: [],
+    boundary_detected: false,
+    constraint_alerts: [],
+    entity_map: {},
+    active_constraints: [],
+  };
+}
+
+// ── Entity Lookup (DB) ───────────────────────────────────────────
+
+/**
+ * Look up entities that appear in the given texts.
+ * Matches case-insensitively against canonical_name and aliases.
+ * Returns empty array if DB is unavailable (graceful degradation).
+ */
+export async function lookupEntities(texts: string[]): Promise<EntityInfo[]> {
+  if (texts.length === 0) return [];
+
+  let queryFn: (text: string, params?: unknown[]) => Promise<{ rows: EntityRow[] }>;
+  try {
+    const { query } = await import("../db/client.js");
+    queryFn = query;
+  } catch {
+    return [];
+  }
+
+  try {
+    // Fetch all entities — table is expected to be small (< 100 rows typically)
+    const result = await queryFn(
+      "SELECT canonical_name, scope, aliases, constraints FROM entities"
+    );
+
+    if (result.rows.length === 0) return [];
+
+    // Combine all texts into one searchable blob for matching
+    const combined = texts.join("\n").toLowerCase();
+
+    const matched: EntityInfo[] = [];
+    for (const row of result.rows) {
+      const names = [row.canonical_name, ...(row.aliases || [])];
+      const found = names.some(
+        (name) => combined.includes(name.toLowerCase())
+      );
+      if (found) {
+        matched.push({
+          canonical_name: row.canonical_name,
+          scope: row.scope as "work" | "personal" | "shared",
+          aliases: row.aliases || [],
+          constraints: row.constraints || [],
+        });
+      }
+    }
+
+    return matched;
+  } catch {
+    // DB query failed — graceful degradation
+    return [];
+  }
+}
+
+// ── Envelope Computation (Pure) ──────────────────────────────────
+
+/**
+ * Compute a context envelope from matched entities.
+ * Pure function — no DB access, fully testable.
+ */
+export function computeEnvelope(entities: EntityInfo[]): ContextEnvelope {
+  if (entities.length === 0) return emptyEnvelope();
+
+  const scopeSet = new Set<string>();
+  const entityMap: Record<string, EntityInfo> = {};
+  const allConstraints: string[] = [];
+  const constraintAlerts: string[] = [];
+
+  for (const entity of entities) {
+    scopeSet.add(entity.scope);
+    entityMap[entity.canonical_name] = entity;
+
+    for (const constraint of entity.constraints) {
+      allConstraints.push(constraint);
+      constraintAlerts.push(`${entity.canonical_name}: ${constraint}`);
+    }
+  }
+
+  const scopeFlags = Array.from(scopeSet).sort();
+  const boundaryDetected = scopeFlags.length > 1;
+
+  return {
+    scope_flags: scopeFlags,
+    boundary_detected: boundaryDetected,
+    constraint_alerts: constraintAlerts,
+    entity_map: entityMap,
+    active_constraints: allConstraints,
+  };
+}
+
+// ── Boundary Notice Generation ───────────────────────────────────
+
+/**
+ * Generate a prose BOUNDARY NOTICE when results span multiple scopes.
+ */
+export function generateBoundaryNotice(envelope: ContextEnvelope): string | null {
+  if (!envelope.boundary_detected) return null;
+
+  const scopeList = envelope.scope_flags.join(", ");
+  const lines: string[] = [
+    `\u26a0\ufe0f BOUNDARY NOTICE: These results span [${scopeList}] scopes.`,
+  ];
+
+  // Group constraints by scope
+  const byScope: Record<string, string[]> = {};
+  for (const [name, entity] of Object.entries(envelope.entity_map)) {
+    if (entity.constraints.length > 0) {
+      if (!byScope[entity.scope]) byScope[entity.scope] = [];
+      for (const c of entity.constraints) {
+        byScope[entity.scope].push(`${name} — ${c}`);
+      }
+    }
+  }
+
+  for (const scope of envelope.scope_flags) {
+    const constraints = byScope[scope] ?? [];
+    if (constraints.length > 0) {
+      lines.push(`Constraints from ${scope} scope: ${constraints.join("; ")}`);
+    }
+  }
+
+  lines.push("DO NOT blend recommendations across scopes without explicitly acknowledging the boundary.");
+
+  return lines.join("\n");
+}

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -202,22 +202,11 @@ Returns: {success, stored_at, filename, task_summary, schema_version}`;
 
 const GET_LATEST_HANDOFF_DESCRIPTION = `Retrieve the most recent handoff state. Returns operational context, active work, task lists, and tone notes from the last session.
 
-Response includes pre-computed fields to avoid inference overhead:
-- elapsed_seconds: Seconds since handoff was stored. Use this, not timestamp math.
-- same_calendar_day: Whether the handoff is from today (user's timezone). If false, operational_state (mood, energy, sleep) is stale and should be confirmed.
-- task_summary: {open_count, blocked_count, completed_count} — pre-computed.
-- applied_scope / filtered_fields: What was filtered (only when scope != "full").
-- schema_version: Response format version.
-- handoff_count: Total handoff files stored (indicates history depth).
-- stored_at_local: Human-readable local time rendering of stored_at.
+WHEN TO CALL: At session start (always), before any store_handoff or patch_handoff (to load current state), and before any evaluative or judgment-class response (to ground reasoning in recorded context, not inference alone).
 
-Full response shape:
-- operational_state: {sleep_hours, physical_state, energy_level, mood}
-- active_context: {session, surface, conversation_arc, key_decisions, prompts_generated, session_meta?}
-- tasks: {open: string[], blocked: string[], completed: string[]}
-- task_summary: {open_count, blocked_count, completed_count}
-- tone_notes: string — Read this before responding. Guidance for approaching the user.
-- timezone, stored_at (UTC), retrieved_at (local), stored_at_local, elapsed_seconds, same_calendar_day, applied_scope, filtered_fields?, schema_version, handoff_count
+Pre-computed fields: elapsed_seconds, same_calendar_day (if false, operational_state is stale — confirm with user), task_summary, applied_scope/filtered_fields, schema_version, handoff_count, stored_at_local.
+
+Response shape: operational_state, active_context, tasks, task_summary, tone_notes (read before responding), timezone, stored_at, retrieved_at, elapsed_seconds, same_calendar_day, schema_version, handoff_count.
 
 Parameters:
 - scope (optional, default "full"): "full" | "work" | "personal"

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -4,6 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { query } from "../db/client.js";
 import { generateEmbedding, isEmbeddingAvailable } from "../embeddings/client.js";
 import { indexAllHandoffs, indexAllTasks } from "../embeddings/indexer.js";
+import { lookupEntities, computeEnvelope, emptyEnvelope, generateBoundaryNotice } from "./entities.js";
 
 /**
  * Normalize text for fingerprinting: lowercase, collapse whitespace, take first 500 chars, then SHA-256.
@@ -70,24 +71,21 @@ export function deduplicateResults(rows: SearchResultRow[]): { deduped: SearchRe
   return { deduped, preDedupCount };
 }
 
-const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content — handoff history, tasks, and documents. Returns results ranked by meaning similarity, not keyword match.
+const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content — handoffs, tasks, documents. Results ranked by meaning similarity.
 
-Use this when the user asks about past decisions, previous conversations, historical context, or when full-text search (search_tasks) might miss results because exact words don't match.
+WHEN TO SEARCH: Proactively before responding about named people, hardware/devices, career/comp, network infra, medical, financial context, or continuity cues ("last time", "we discussed").
 
-Parameters:
-  - query (required): Natural language search query
-  - content_types (optional): Filter by type. Default: all. Options: 'handoff', 'task', 'document', 'transcript'
-  - limit (optional): Max results. Default: 5, max: 20
-  - similarity_threshold (optional): Minimum cosine similarity (0-1). Default: 0.15
-  - hybrid (optional): Enable hybrid search (vector + full-text with RRF fusion). Default: true
+QUERY TIPS: Natural language, include entity names. People: full name. Devices: user's name for it.
 
-Returns: Array of {content_type, content_id, content_text (truncated), metadata, similarity}
+READ context_envelope FIRST. If boundary_detected=true or constraint_alerts non-empty, address constraints before recommendations.
 
-Retrieval guidance: If results appear to reference an event, decision, or incident indirectly (e.g., "the deployment issue was resolved" rather than describing what actually happened), the original source may exist deeper in the index. Reformulate your query with more specific contextual terms (names, locations, actions) and search again with a lower similarity_threshold (try 0.05) and higher limit (try 20). Prefer results from the oldest source_file — the filename timestamp indicates when the content was originally captured.`;
+Returns: {results[], context_envelope, query, total, mode, deduplicated, pre_dedup_count}
 
-const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs and tasks. Use after bulk data changes or when search results seem stale.
+If results reference events indirectly, reformulate with specific terms, lower threshold (0.05), higher limit (20).`;
 
-WARNING: This operation can take several minutes for large datasets (1000+ handoffs). It re-embeds all content, not just changed items. Inform the user of expected duration before running.
+const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs and tasks. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
+
+WARNING: Can take several minutes for large datasets (1000+ handoffs). Re-embeds all content, not just changed items. Inform the user of expected duration before running.
 
 Parameters:
   - content_types (optional): Which to reindex. Default: all. Options: 'handoff', 'task'
@@ -216,6 +214,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
                 mode: useHybrid ? "hybrid" : "vector",
                 deduplicated: true,
                 pre_dedup_count: 0,
+                context_envelope: emptyEnvelope(),
               }),
             }],
           };
@@ -233,28 +232,44 @@ export function registerSearchTools(mcpServer: McpServer): void {
         });
         const finalRows = deduped.slice(0, limit);
 
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({
-              results: finalRows.map((r: SearchResultRow) => ({
-                content_type: r.content_type,
-                content_id: r.content_id,
-                content_text: r.content_text,
-                metadata: r.metadata,
-                similarity: Math.round((r.similarity ?? 0) * 1000) / 1000,
-                ...(r.rrf_score ? { rrf_score: Math.round(r.rrf_score * 10000) / 10000 } : {}),
-                ...(r.metadata?.chunk_index != null ? { chunk_index: r.metadata.chunk_index } : {}),
-                ...(r.metadata?.source_file ? { source_file: r.metadata.source_file } : {}),
-              })),
-              query: args.query,
-              total: finalRows.length,
-              mode: useHybrid ? "hybrid" : "vector",
-              deduplicated: true,
-              pre_dedup_count: preDedupCount,
-            }),
-          }],
+        // Compute context envelope from entity matches (best-effort)
+        const resultTexts = finalRows.map((r) => r.content_text ?? "");
+        let envelope;
+        try {
+          const entities = await lookupEntities(resultTexts);
+          envelope = computeEnvelope(entities);
+        } catch {
+          envelope = emptyEnvelope();
+        }
+
+        const responseData = {
+          results: finalRows.map((r: SearchResultRow) => ({
+            content_type: r.content_type,
+            content_id: r.content_id,
+            content_text: r.content_text,
+            metadata: r.metadata,
+            similarity: Math.round((r.similarity ?? 0) * 1000) / 1000,
+            ...(r.rrf_score ? { rrf_score: Math.round(r.rrf_score * 10000) / 10000 } : {}),
+            ...(r.metadata?.chunk_index != null ? { chunk_index: r.metadata.chunk_index } : {}),
+            ...(r.metadata?.source_file ? { source_file: r.metadata.source_file } : {}),
+          })),
+          query: args.query,
+          total: finalRows.length,
+          mode: useHybrid ? "hybrid" : "vector",
+          deduplicated: true,
+          pre_dedup_count: preDedupCount,
+          context_envelope: envelope,
         };
+
+        // Build MCP content array — prepend boundary notice if detected
+        const contentItems: { type: "text"; text: string }[] = [];
+        const boundaryNotice = generateBoundaryNotice(envelope);
+        if (boundaryNotice) {
+          contentItems.push({ type: "text" as const, text: boundaryNotice });
+        }
+        contentItems.push({ type: "text" as const, text: JSON.stringify(responseData) });
+
+        return { content: contentItems };
       } catch (err) {
         return {
           content: [{

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -65,13 +65,17 @@ This is the authoritative task store — do not maintain parallel task lists in 
 
 const GET_TASK_DESC = `Retrieve a single task by its UUID. Returns all fields including timestamps and tags.`;
 
-const LIST_TASKS_DESC = `List tasks with optional filters. Defaults to showing open tasks sorted by creation date (newest first). Use status=null to query across all statuses. Tags filter uses ANY-match (task has at least one of the provided tags). Blocked filter isolates tasks with/without a blocked_reason.
+const LIST_TASKS_DESC = `List tasks with optional filters. Defaults to showing open tasks sorted by creation date (newest first). Use status=null to query across all statuses. Tags filter uses ANY-match. Blocked filter isolates tasks with/without a blocked_reason.
+
+WHEN TO PULL TASKS: Before any evaluative response (performance reviews, weekly check-ins, compensation assessments, progress reports), pull task data to ground your assessment in tracked work — not memory alone.
 
 This is the authoritative task store — do not maintain parallel task lists in handoff state or external systems.`;
 
 const UPDATE_TASK_DESC = `Update a task's fields and/or apply a lifecycle action. Actions are convenience shortcuts: 'complete' marks done with timestamp, 'cancel' marks cancelled, 'defer' parks the task, 'reopen' returns to open. Field updates can accompany any action. Tags are full-replacement (provide complete array). Set blocked_reason to null to unblock.`;
 
-const SEARCH_TASKS_DESC = `Full-text search across task titles and context. Uses PostgreSQL FTS with English stemming. Optionally filter by status and scope. Results ranked by relevance. Useful for finding tasks by keyword when you don't know the exact title.`;
+const SEARCH_TASKS_DESC = `Full-text search across task titles and context. Uses PostgreSQL FTS with English stemming. Filter by status and scope. Results ranked by relevance.
+
+WHEN TO SEARCH TASKS: When a request mentions a task by keyword, when preparing evaluative responses (reviews, assessments), or when you need to verify task status before making recommendations. Use this when exact title is unknown — list_tasks is better when you want filtered browsing.`;
 
 // ── Tool Registration ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Addresses the synthesis gap where models read search results but fail to integrate scope boundaries and entity constraints into their recommendations. A live test showed `search_context` returning correct boundary info (company-owned device, banned app), but the model still recommended the banned app.

v0.5.1 makes constraints **first-class structured data** in tool responses:

- **Entity table** (`003_entities.sql`): Schema for canonical entities with scope, aliases, and constraints. Data loads from deployment-local seed files (never committed).
- **Context envelope**: New `context_envelope` field on `search_context` responses containing `scope_flags`, `boundary_detected`, `constraint_alerts`, `entity_map`, and `active_constraints`.
- **Boundary notice**: Prose `BOUNDARY NOTICE` prepended to MCP response when results span multiple scopes.
- **Proactive tool descriptions**: Updated `search_context`, `reindex`, `list_tasks`, `search_tasks`, and `get_latest_handoff` descriptions with guidance on *when* to call each tool.
- **Entity seed infrastructure**: Configurable `ENTITY_SEED_PATH` (default: `./data/entities.seed.json`), idempotent upsert, graceful degradation when DB or file is missing.

### Privacy verification

- No personal data (names, devices, domains, relationships, employer name) in any committed file
- `entities.seed.json` added to `.gitignore`
- Only `entities.seed.example.json` with generic placeholders is committed
- All test fixtures use generic names ("Work Laptop", "Home Server", "Dev Desktop", "Project Alpha")

### Description character counts

| Description | Chars | OpenAI 1024 limit |
|---|---|---|
| SEARCH_CONTEXT_DESCRIPTION | 738 | OK |
| REINDEX_DESCRIPTION | 514 | OK |
| LIST_TASKS_DESC | 567 | OK |
| SEARCH_TASKS_DESC | 437 | OK |
| GET_LATEST_HANDOFF_DESCRIPTION | 922 | OK |
| STORE_HANDOFF_DESCRIPTION | 1566 | Pre-existing, unchanged |
| PATCH_HANDOFF_DESCRIPTION | 2087 | Pre-existing, unchanged |

### Deferred to v0.5.2

- `last_referenced` timestamp tracking (column exists but not populated)
- Per-model response format tuning
- Callback validation via secondary model
- Judgment-class request gating / `evidence_pulled` field
- CLI `extract-entities` bootstrap script

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm test` — all 82 tests pass (29 skipped: no Postgres in test env)
- [x] New entity/envelope unit tests cover: work-only, personal-only, mixed-scope boundary, no-match, boundary notice generation
- [x] No personal data in any committed file
- [ ] CI pipeline (build, test, Snyk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)