### PR TITLE
chore: pipeline hardening — Dockerfile fix, Postgres CI, reusable workflows, notifications, version bump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,10 @@ EMBEDDING_DIMENSIONS=768
 # AUTH0_CLIENT_SECRET=
 # ALLOWED_USERS=user@example.com
 # EXTERNAL_URL=https://context-library.example.com
+
+# ── Notifications ────────────────────────────────────────
+# Push notification URL for CI/CD pipeline events.
+# Default: https://ntfy.sh/context-library-ci (public ntfy instance)
+# For self-hosted: https://your-ntfy-server/your-topic
+# Set as GitHub Actions secret NTFY_URL for private topics.
+# NTFY_URL=https://ntfy.sh/context-library-ci

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       SNYK_TOKEN:
         required: true
+      NTFY_URL:
+        required: false
 
 jobs:
   ci:
@@ -47,3 +49,21 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --severity-threshold=high
+
+      - name: Notify on completion
+        if: always()
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+        run: |
+          STATUS="${{ job.status }}"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TITLE="PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+          else
+            TITLE="Push to ${{ github.ref_name }}"
+          fi
+          curl -s -o /dev/null \
+            -H "Title: CI ${STATUS}: ${TITLE}" \
+            -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "high" )" \
+            -H "Tags: $( [ "$STATUS" = "success" ] && echo "white_check_mark" || echo "x" )" \
+            -d "Build ${STATUS} for context-library" \
+            "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,49 @@
+name: ci-checks
+
+on:
+  workflow_call:
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: cl_test
+          POSTGRES_USER: cl
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cl -d cl_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGDATABASE: cl_test
+      PGUSER: cl
+      PGPASSWORD: test
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      - name: Snyk dependency scan
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,44 +11,6 @@ permissions:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_DB: cl_test
-          POSTGRES_USER: cl
-          POSTGRES_PASSWORD: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U cl -d cl_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      PGHOST: localhost
-      PGPORT: 5432
-      PGDATABASE: cl_test
-      PGUSER: cl
-      PGPASSWORD: test
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npm run build
-
-      - run: npm test
-
-      - name: Snyk dependency scan
-        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --severity-threshold=high
+    uses: ./.github/workflows/ci-checks.yml
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
     uses: ./.github/workflows/ci-checks.yml
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      NTFY_URL: ${{ secrets.NTFY_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,26 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: cl_test
+          POSTGRES_USER: cl
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cl -d cl_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGDATABASE: cl_test
+      PGUSER: cl
+      PGPASSWORD: test
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,51 +9,20 @@ permissions:
   packages: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci-checks.yml
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
   release:
+    needs: ci
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_DB: cl_test
-          POSTGRES_USER: cl
-          POSTGRES_PASSWORD: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U cl -d cl_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      PGHOST: localhost
-      PGPORT: 5432
-      PGDATABASE: cl_test
-      PGUSER: cl
-      PGPASSWORD: test
+    permissions:
+      contents: read
+      packages: write
     steps:
-      # --- CI gates (same as ci.yml) ---
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npm run build
-
-      - run: npm test
-
-      - name: Snyk dependency scan
-        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --severity-threshold=high
-
-      # --- Docker build + container scan + publish ---
       - name: Extract version from tag
         id: version
         run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,5 @@ jobs:
             -H "Title: Release ${STATUS}: v${{ steps.version.outputs.tag }}" \
             -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "urgent" )" \
             -H "Tags: $( [ "$STATUS" = "success" ] && echo "rocket" || echo "rotating_light" )" \
-            -d "Context Library v${{ steps.version.outputs.tag }} — image $( [ '$STATUS' = 'success' ] && echo 'published to GHCR' || echo 'FAILED to publish' )" \
+            -d "Context Library v${{ steps.version.outputs.tag }} — image $( [ "$STATUS" = "success" ] && echo 'published to GHCR' || echo 'FAILED to publish' )" \
             "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/ci-checks.yml
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      NTFY_URL: ${{ secrets.NTFY_URL }}
 
   release:
     needs: ci
@@ -50,3 +51,16 @@ jobs:
         run: |
           docker push ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
           docker push ghcr.io/onideus/context-library:latest
+
+      - name: Notify on release
+        if: always()
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+        run: |
+          STATUS="${{ job.status }}"
+          curl -s -o /dev/null \
+            -H "Title: Release ${STATUS}: v${{ steps.version.outputs.tag }}" \
+            -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "urgent" )" \
+            -H "Tags: $( [ "$STATUS" = "success" ] && echo "rocket" || echo "rotating_light" )" \
+            -d "Context Library v${{ steps.version.outputs.tag }} — image $( [ '$STATUS' = 'success' ] && echo 'published to GHCR' || echo 'FAILED to publish' )" \
+            "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,26 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: cl_test
+          POSTGRES_USER: cl
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cl -d cl_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGDATABASE: cl_test
+      PGUSER: cl
+      PGPASSWORD: test
     steps:
       # --- CI gates (same as ci.yml) ---
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -41,6 +61,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
+            --build-arg APP_VERSION=${{ steps.version.outputs.tag }} \
             -t ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }} \
             -t ghcr.io/onideus/context-library:latest \
             .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-# Extract version for runtime ENV (avoids runtime fs read of package.json)
-RUN node -e "console.log(require('./package.json').version)" > /tmp/version.txt
-
 # Stage 2: Production
 FROM node:22-slim
 
@@ -25,15 +22,11 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 COPY --chown=appuser:appgroup --from=builder /app/dist ./dist
 COPY --chown=appuser:appgroup src/db/migrations ./dist/db/migrations
-COPY --from=builder /tmp/version.txt /tmp/version.txt
 
 RUN mkdir -p /app/data && \
     chown -R appuser:appgroup /app/data
 
-# Inject version so server.ts reads from env, not filesystem
-ENV APP_VERSION=
-RUN APP_VERSION=$(cat /tmp/version.txt | tr -d '\n') && \
-    echo "APP_VERSION=$APP_VERSION" >> /etc/environment
+ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
 USER appuser

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,13 +20,23 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - Three-tier Docker Compose deployment (core → Postgres → embeddings)
 - Scope filtering (full/work/personal) on handoff retrieval
 - Open-source release preparation (v0.5.0)
+- CI/CD pipeline with Snyk gates and GHCR publishing (GitHub Actions)
+- TEI compose profiles for GPU and CPU deployment
+- Entity system with context envelopes for entity-aware search
 
-## Current: v0.5.0 Initial Release
+## Current: v0.5.1
 
-- Security audit (logging sanitization, secrets parameterization)
-- Test coverage (unit tests for merge logic, extraction, chunking)
-- Documentation (README, ROADMAP, CONTRIBUTING)
-- Tool description accuracy audit
+- Entity system: canonical names, aliases, scope, constraints, boundary notices
+- JIT context envelopes injected into search results when entities are referenced
+- Proactive tool descriptions updated to reflect entity awareness
+- Pipeline hardening: Dockerfile fix, Postgres CI, reusable workflows, notifications
+
+## Next: v0.5.2
+
+- Judgment-class request gating (`evidence_pulled` field)
+- Per-model response format tuning
+- CLI `extract-entities` bootstrap script
+- `last_referenced` timestamp population
 
 ## Future
 
@@ -57,5 +67,4 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - Calendar/scheduling data feeds
 
 ### Infrastructure
-- CI/CD pipeline (GitHub Actions)
 - Refactor dynamic SQL assembly in search tools to a query builder pattern for maintainability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-library",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-library",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@hono/mcp": "^0.2.4",
         "@hono/node-server": "^1.19.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-library",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

- **fix: Dockerfile APP_VERSION injection** — replaced broken ENV/RUN/ENV pattern with ARG/ENV. Version now passed via `--build-arg` from release workflow. Local builds fall back to reading package.json at runtime.
- **ci: add PostgreSQL service container** — pgvector/pgvector:pg16 with health checks. Unlocks 29 previously skipped integration tests (task CRUD, search, entities).
- **refactor: extract CI steps into reusable workflow** — `ci-checks.yml` called by both `ci.yml` and `release.yml`. Eliminates duplication of steps, Postgres service, and env vars.
- **feat: ntfy push notifications** — CI and release pipelines send push notifications via ntfy.sh. Configurable via `NTFY_URL` secret. Failures never block the build (`|| true`).
- **chore: bump version to 0.5.1** — package.json + package-lock.json updated.
- **docs: update ROADMAP.md** — moved CI/CD, TEI profiles, and entity system to Completed. Added v0.5.2 scope. Removed stale Infrastructure/CI entry.

## Post-merge steps

1. Push `v0.5.1` tag to trigger the first real release pipeline execution
2. Add `NTFY_URL` as a GitHub Actions secret (or use the public default for testing)
3. Subscribe to the ntfy topic for notifications

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm test` passes (82 passed, 29 skipped — those require Postgres, now available in CI)
- [x] `docker build --build-arg APP_VERSION=0.5.1 .` succeeds
- [x] Container reports `APP_VERSION=0.5.1` via `printenv`
- [x] All three workflow files are valid YAML
- [x] No personal data in any committed file
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)