### PR TITLE
chore: pipeline tag-release promotion model

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,92 @@
+name: cleanup
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+env:
+  OWNER: onideus
+  PACKAGE: context-library
+  RETENTION_DAYS: 90
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Prune old SHA-tagged images
+        id: prune
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch=$(date -u -d "${RETENTION_DAYS} days ago" +%s)
+          pruned=0
+          preserved=0
+
+          gh api --paginate \
+            "/users/${OWNER}/packages/container/${PACKAGE}/versions" \
+            > versions.json
+
+          while read -r version; do
+            id=$(echo "$version" | jq -r '.id')
+            updated=$(echo "$version" | jq -r '.updated_at')
+            tags_csv=$(echo "$version" | jq -r '[.metadata.container.tags[]?] | join(",")')
+
+            if [ -z "$tags_csv" ]; then
+              echo "SKIP id=$id — untagged version"
+              continue
+            fi
+
+            has_release_tag=false
+            while IFS= read -r t; do
+              [ -z "$t" ] && continue
+              case "$t" in
+                sha-*) : ;;
+                *) has_release_tag=true ;;
+              esac
+            done < <(echo "$version" | jq -r '.metadata.container.tags[]?')
+
+            if $has_release_tag; then
+              echo "PRESERVE id=$id tags=[$tags_csv] — referenced by release"
+              preserved=$((preserved + 1))
+              continue
+            fi
+
+            updated_epoch=$(date -u -d "$updated" +%s)
+            if [ "$updated_epoch" -ge "$cutoff_epoch" ]; then
+              echo "PRESERVE id=$id tags=[$tags_csv] — within ${RETENTION_DAYS}-day retention window"
+              preserved=$((preserved + 1))
+              continue
+            fi
+
+            echo "PRUNE id=$id tags=[$tags_csv] updated=$updated"
+            gh api --method DELETE \
+              "/users/${OWNER}/packages/container/${PACKAGE}/versions/${id}"
+            pruned=$((pruned + 1))
+          done < <(jq -c '.[]' versions.json)
+
+          echo "Summary: pruned=${pruned}, preserved=${preserved}"
+          echo "pruned=${pruned}" >> "$GITHUB_OUTPUT"
+          echo "preserved=${preserved}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify on completion
+        if: always()
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+        run: |
+          STATUS="${{ job.status }}"
+          PRUNED="${{ steps.prune.outputs.pruned || '?' }}"
+          PRESERVED="${{ steps.prune.outputs.preserved || '?' }}"
+          curl -s -o /dev/null \
+            -H "Title: GHCR cleanup ${STATUS}" \
+            -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "high" )" \
+            -H "Tags: $( [ "$STATUS" = "success" ] && echo "broom" || echo "x" )" \
+            -d "Pruned ${PRUNED}, preserved ${PRESERVED}" \
+            "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,70 @@
+name: image
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci-checks.yml
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      NTFY_URL: ${{ secrets.NTFY_URL }}
+
+  image:
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg APP_VERSION=${{ steps.version.outputs.version }} \
+            -t ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
+            .
+
+      # --exclude-base-image-vulns: ignore CVEs inherited from node:22-slim
+      # (e.g. zlib) that we can't patch ourselves. Snyk will still flag any
+      # vulnerability introduced in our own layers.
+      - name: Snyk container scan
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }}
+          args: --severity-threshold=high --exclude-base-image-vulns
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push SHA-tagged image to GHCR
+        run: docker push ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }}
+
+      - name: Notify on completion
+        if: always()
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+        run: |
+          STATUS="${{ job.status }}"
+          curl -s -o /dev/null \
+            -H "Title: Image ${STATUS}: sha-${{ steps.sha.outputs.short_sha }}" \
+            -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "high" )" \
+            -H "Tags: $( [ "$STATUS" = "success" ] && echo "white_check_mark" || echo "x" )" \
+            -d "Image build ${STATUS} for sha-${{ steps.sha.outputs.short_sha }}" \
+            "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,14 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci-checks.yml
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      NTFY_URL: ${{ secrets.NTFY_URL }}
-
   release:
-    needs: ci
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -28,32 +21,35 @@ jobs:
         id: version
         run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build Docker image
-        run: |
-          docker build \
-            --build-arg APP_VERSION=${{ steps.version.outputs.tag }} \
-            -t ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }} \
-            -t ghcr.io/onideus/context-library:latest \
-            .
-
-      # --exclude-base-image-vulns: ignore CVEs inherited from node:22-slim
-      # (e.g. zlib) that we can't patch ourselves. Snyk will still flag any
-      # vulnerability introduced in our own layers.
-      - name: Snyk container scan
-        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
-          args: --severity-threshold=high --exclude-base-image-vulns
+      - name: Compute short SHA
+        id: sha
+        run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push to GHCR
+      - name: Verify SHA image exists
         run: |
+          if ! docker pull ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }}; then
+            echo "::error::No validated image found for sha-${{ steps.sha.outputs.short_sha }}. Ensure the commit was merged to main and the image pipeline succeeded before tagging a release."
+            exit 1
+          fi
+
+      - name: Retag and push release tags
+        run: |
+          docker tag \
+            ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
+            ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
+          docker tag \
+            ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
+            ghcr.io/onideus/context-library:latest
           docker push ghcr.io/onideus/context-library:${{ steps.version.outputs.tag }}
           docker push ghcr.io/onideus/context-library:latest
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
 
       - name: Notify on release
         if: always()
@@ -65,5 +61,5 @@ jobs:
             -H "Title: Release ${STATUS}: v${{ steps.version.outputs.tag }}" \
             -H "Priority: $( [ "$STATUS" = "success" ] && echo "default" || echo "urgent" )" \
             -H "Tags: $( [ "$STATUS" = "success" ] && echo "rocket" || echo "rotating_light" )" \
-            -d "Context Library v${{ steps.version.outputs.tag }} — image $( [ "$STATUS" = "success" ] && echo 'published to GHCR' || echo 'FAILED to publish' )" \
+            -d "Context Library v${{ steps.version.outputs.tag }} — release $( [ "$STATUS" = "success" ] && echo 'published' || echo 'FAILED' )" \
             "${NTFY_URL:-https://ntfy.sh/context-library-ci}" || true


### PR DESCRIPTION
## Summary
- **`image.yml`** (new): push to main → ci-checks → build → Snyk container scan → push `sha-<short>` to GHCR. Scan gates the push — insecure images never reach the registry.
- **`release.yml`** (rewritten): tag `v*` → pull `sha-<short>` image → fail clearly if missing → retag as `<version>` + `:latest` → push → `gh release create --generate-notes --verify-tag`.
- **`cleanup.yml`** (new): weekly cron + `workflow_dispatch` → prune `sha-*` GHCR versions older than `RETENTION_DAYS` (90) unless a release tag references the same manifest.

## Why
Under the old flow, `release.yml` built and scanned the image *after* the tag was public. A Snyk failure post-tag meant the release was blocked but the tag remained — you had to cut a new tag to retry. The promotion model decouples validation (at merge) from release (at tag), so by the time a release tag exists, the image it points to has already passed every gate.

## Files unchanged
`ci-checks.yml`, `ci.yml`, `Dockerfile`, `package.json`. Same Snyk action SHA and flags (`--severity-threshold=high --exclude-base-image-vulns`) as the v0.5.3 release scan that currently passes.

## Test plan
- [x] PR triggers `ci.yml` only (no `image.yml`, no `release.yml`)
- [ ] After merge, push to `main` triggers `ci.yml` AND `image.yml`; `image.yml` pushes a `sha-<short>` tag to GHCR only if Snyk passes
- [ ] Tag `v0.5.4` on the merge commit triggers `release.yml`, which pulls the `sha-<short>` image, retags as `0.5.4` + `latest`, pushes both, and creates a GitHub Release with auto-generated notes
- [ ] Tagging a commit with no corresponding `sha-<short>` image fails the release workflow with a clear error
- [ ] `cleanup.yml` runs manually via `workflow_dispatch` and logs PRUNE/PRESERVE decisions; release-referenced SHA images are preserved
- [ ] Ntfy notifications fire on success and failure for all three workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)