### PR TITLE
fix: invoke snyk CLI directly so container scan flags word-split

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -39,16 +39,24 @@ jobs:
             -t ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
             .
 
+      # snyk/actions/docker passes `args:` as a single quoted string to the CLI,
+      # collapsing "--severity-threshold=high --exclude-base-image-vulns" into
+      # one unparseable token and silently dropping the base-image exclusion.
+      # Install the CLI and invoke it directly so flags word-split correctly.
       # --exclude-base-image-vulns: ignore CVEs inherited from node:22-slim
-      # (e.g. zlib) that we can't patch ourselves. Snyk will still flag any
-      # vulnerability introduced in our own layers.
+      # (e.g. zlib) that we can't patch ourselves. Snyk still flags vulns
+      # introduced in our own layers.
+      - name: Set up Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+
       - name: Snyk container scan
-        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }}
-          args: --severity-threshold=high --exclude-base-image-vulns
+        run: |
+          snyk container test \
+            ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
+            --severity-threshold=high \
+            --exclude-base-image-vulns
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
## Summary
- `snyk/actions/docker` passes the `args:` input to the CLI as one quoted string, so `--severity-threshold=high --exclude-base-image-vulns` arrives as a single unparseable token and the base-image exclusion is silently dropped.
- Replace the action with `snyk/actions/setup` + a direct `snyk container test` invocation so flags land as separate argv entries.

## Why
The base-image zlib CVE is expected (inherited from `node:22-slim`, unpatched upstream) and is exactly what `--exclude-base-image-vulns` is supposed to suppress. Because that flag wasn't actually reaching the CLI, every container scan has failed on it — see v0.5.3 release run [24528573826](https://github.com/onideus/context-library/actions/runs/24528573826) and the first `image.yml` run on main [24549915001](https://github.com/onideus/context-library/actions/runs/24549915001), both with identical output:

```
snyk test "--severity-threshold=high --exclude-base-image-vulns" --docker ghcr.io/onideus/context-library:...
✗ Critical severity vulnerability found in zlib/zlib1g
```

Direct CLI invocation fixes the argv issue without changing scan intent.

## Test plan
- [ ] Merge triggers `image.yml` on main
- [ ] Snyk step logs show the two flags as separate argv entries
- [ ] Scan passes (zlib base-image CVE excluded)
- [ ] `sha-<short>` image is pushed to GHCR
- [ ] Ntfy fires success notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)