### PR TITLE
fix: pass --file=Dockerfile to snyk container test

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -43,6 +43,10 @@ jobs:
       # collapsing "--severity-threshold=high --exclude-base-image-vulns" into
       # one unparseable token and silently dropping the base-image exclusion.
       # Install the CLI and invoke it directly so flags word-split correctly.
+      # --file: Snyk can't identify the base image from a registry image alone,
+      # so --exclude-base-image-vulns has nothing to exclude against. Pointing
+      # at the Dockerfile lets Snyk resolve the FROM line and attribute vulns
+      # correctly. Without this, the zlib CVE from node:22-slim fails the scan.
       # --exclude-base-image-vulns: ignore CVEs inherited from node:22-slim
       # (e.g. zlib) that we can't patch ourselves. Snyk still flags vulns
       # introduced in our own layers.
@@ -55,6 +59,7 @@ jobs:
         run: |
           snyk container test \
             ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }} \
+            --file=Dockerfile \
             --severity-threshold=high \
             --exclude-base-image-vulns
 


### PR DESCRIPTION
## Summary
Add `--file=Dockerfile` to the `snyk container test` invocation in `image.yml` so `--exclude-base-image-vulns` can actually do its job.

## Why
Snyk can't identify the base image from a registry image by itself — it needs the Dockerfile to resolve the `FROM` line. Without `--file`, `--exclude-base-image-vulns` has nothing to exclude *against*, so the base-image zlib CVE (inherited from `node:22-slim`, unpatched upstream) fails the scan.

The previous run on main ([24550327482](https://github.com/onideus/context-library/actions/runs/24550327482)) surfaced exactly this:

```
Snyk wasn't able to auto detect the base image, use `--file` option to get base image remediation advice.
✗ Critical severity vulnerability found in zlib/zlib1g
```

Pointing at the Dockerfile lets Snyk attribute vulns to the base vs. our own layers so the exclusion applies.

## Test plan
- [ ] Merge triggers `image.yml` on main
- [ ] Snyk step no longer logs the "wasn't able to auto detect" warning
- [ ] Scan passes (zlib base-image CVE excluded)
- [ ] `sha-<short>` image pushed to GHCR
- [ ] Ntfy fires success

🤖 Generated with [Claude Code](https://claude.com/claude-code)