### PR TITLE
feat: v0.5.4 — server-side enforcement, extract-entities CLI, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ logs/
 proxy-certs/
 proxy-data/
 .claude/worktrees/
+.claude/settings.local.json
 entities.seed.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,7 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 
 ## Completed
 
+### v0.5.0 — Open Source Release
 - Handoff tools (store, get, patch) with append-only file storage
 - Task management (CRUD + full-text search) on PostgreSQL
 - Semantic search via pgvector + TEI embeddings with hybrid RRF fusion
@@ -19,52 +20,73 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - OAuth delegated to mcp-auth-proxy
 - Three-tier Docker Compose deployment (core → Postgres → embeddings)
 - Scope filtering (full/work/personal) on handoff retrieval
-- Open-source release preparation (v0.5.0)
-- CI/CD pipeline with Snyk gates and GHCR publishing (GitHub Actions)
-- TEI compose profiles for GPU and CPU deployment
-- Entity system with context envelopes for entity-aware search
+- Open-source release preparation
 
-## Current: v0.5.1
-
+### v0.5.1 — JIT Context & Entity System
 - Entity system: canonical names, aliases, scope, constraints, boundary notices
 - JIT context envelopes injected into search results when entities are referenced
 - Proactive tool descriptions updated to reflect entity awareness
 - Pipeline hardening: Dockerfile fix, Postgres CI, reusable workflows, notifications
 
-## Next: v0.5.2
+### Pipeline Refactor (post-v0.5.1)
+- Tag release promotion model: insecure images never reach GHCR
+- `image.yml` builds, scans (Snyk), and pushes SHA-tagged images on main merge
+- `release.yml` retags validated SHA images as version + latest on tag push
+- `cleanup.yml` prunes SHA images weekly (90-day retention, release tags preserved)
+- `workflow_dispatch` escape hatch for manual release promotion
+- CI runs on every push to main (build + scan gate before GHCR push)
+- CVE suppressions via `.snyk` for upstream-unfixable vulnerabilities (zlib1g, picomatch)
+- npm audit clean (path-to-regexp override to 8.4.2)
+- CLAUDE.md Personal Data Prohibition section for OSS safety
+- TEI compose profiles for GPU (NVIDIA CUDA) and CPU deployment
 
-- Judgment-class request gating (`evidence_pulled` field)
-- Per-model response format tuning
-- CLI `extract-entities` bootstrap script
-- `last_referenced` timestamp population
+> **Note on version gaps:** Tags v0.5.2 and v0.5.3 were consumed during release pipeline testing (Snyk container scan failures). v0.5.4-rc.0 and v0.5.4-test.1 verified the new promotion model. The next release is v0.5.4.
 
-## Future
+## Current: v0.5.4 — Server-Side Enforcement & Cleanup
 
-### LLM Bootstrap Files
-- Per-environment configuration files for different AI assistants and coding tools
-- Goal: anyone can use their preferred LLM/environment with a bootstrap file that provides project context
-- Examples: CLAUDE.md (Claude Code), .cursorrules (Cursor), AGENTS.md (Codex), custom system prompts
-- Each file teaches the respective tool about Context Library's architecture, conventions, and development workflow
+- `evidence_pulled` field for judgment-class request gating (advisory, not blocking)
+- Per-model response format tuning in tool descriptions
+- CLI `extract-entities` bootstrap script (batch entity extraction from handoff corpus)
+- `last_referenced` timestamp population on entity table
+- `z.any()` → `z.unknown()` migration in handoff schemas and tool parameters
+- Docker Compose embeddings port mapping for externalized TEI deployments
+- Tool description updates for new capabilities
+- Version bump to 0.5.4
 
-### Knowledge Layer (Third Primitive)
-- `notes` table in PostgreSQL: id, title, content (interpretation, not summary), source_url, source_title, scope, tags, timestamps
-- MCP tools: `create_note`, `search_notes`, `list_notes`, `get_note`
-- Embedded into pgvector alongside handoffs and tasks for unified semantic search
-- Distinct from artifact storage (file attachments) — knowledge is first-class, not metadata on another object
+## Next: v0.6 — Resilience & Retrieval
 
-### Schema Evolution
-- Handoff schema versioning strategy for forward/backward compatibility
-- Migration tooling for schema changes across stored handoff files
-- Evaluate migrating append-only JSON handoffs to PostgreSQL events table
-- Migrate `z.any()` to `z.unknown()` in handoff schemas and tool parameter definitions for stricter type safety
+Focus: make the system self-healing, observable, and harder to misuse.
 
-### Artifact Storage
-- File/content storage with metadata, SHA-256 hashing, versioning
-- Prompt library via tagging convention on artifacts
+- **Embedding resilience:** `embedding_status` field in `get_latest_handoff` response (TEI health + pending count); pending embeddings queue with dead-letter pattern for TEI outage recovery (O(k) recovery vs O(n) full reindex)
+- **Handoff navigation:** `list_handoffs` and `get_handoff` MCP tools for historical handoff browsing and retrieval
+- **Dynamic task summary:** Server-side computed task summary in `get_latest_handoff` — critical items, due this week, recently completed, blocked chains (replaces basic counts)
+- **Security hardening:** Scope enforcement on task tools (propagate handoff scope as session default); input size limits on store/patch/create operations
+- **Retrieval quality:** Cross-encoder rerank stage after RRF fusion (TEI with MiniLM, ~30-50 lines in search.ts); search alias expansion table for abbreviation/term mapping; entity word-boundary matching; date-range filtering on `search_context`
+- **Automated handoff compaction:** Session-boundary pruning with vector archival — keeps handoffs small, history searchable
+- **Schema hygiene:** `schema_version` field on handoffs for forward/backward compatibility
 
-### Integrations
-- Health/wearable data integration (e.g., Oura, Whoop, Apple Health)
-- Calendar/scheduling data feeds
+## Future: v0.7 — New Primitives
 
-### Infrastructure
-- Refactor dynamic SQL assembly in search tools to a query builder pattern for maintainability
+Focus: expand beyond handoffs and tasks into permanent knowledge and richer structure.
+
+- **Knowledge layer (third primitive):** `notes` table in PostgreSQL with MCP tools (`create_note`, `search_notes`, `list_notes`, `get_note`); embedded into pgvector for unified semantic search; distinct from artifacts — knowledge is interpretation, not output
+- **Artifact storage:** File/content tracking with metadata, SHA-256 hashing, and versioning; prompt library via tagging convention
+- **Task schema evolution:** Subtasks (parent_id), relations (blocks/blocked-by/related), custom fields (JSONB UDAs); hierarchy is opt-in, flat tasks remain the default
+- **Bitemporal entity constraints:** `valid_from`/`valid_until` on entities to prevent stale constraint application
+
+## Horizon
+
+Items with clear value but no target version. Some depend on external spec maturity (MCP elicitation/sampling), others on scale thresholds or ecosystem readiness.
+
+- **MCP elicitation-based judgment gating:** Replaces `evidence_pulled` prose advisory with schema-enforced form input (depends on MCP 2025-11-25 spec reaching stable transport support)
+- **MCP sampling for entity extraction:** Collapses CLI `extract-entities` into an MCP tool via `requestSampling`, removing `@anthropic-ai/sdk` dependency
+- **Conversation transcript indexing:** New `transcript` content type in embedding pipeline; requires chunking strategy and conversation export path
+- **Health/wearable data integration:** Oura Ring API pipeline for sleep, HRV, activity data
+- **Static ICS calendar feed:** Generate `.ics` from tasks with `due_date`/`scheduled_date` for calendar subscription
+- **TTFT measurement tool:** React artifact for A/B testing context injection latency across payload sizes
+- **LLM bootstrap files:** Per-environment config for AI assistants beyond Claude Code (`.cursorrules`, `AGENTS.md`, custom system prompts)
+- **Handoff migration to PostgreSQL:** Evaluate moving append-only JSON handoffs to a Postgres events table
+- **Query builder refactor:** Replace dynamic SQL assembly in search tools with a query builder pattern
+- **Model-agnostic tool description compatibility:** Two-tier system for tool descriptions that adapts to model capability
+- **Entity/keyword metadata extraction:** Automated entity extraction during embedding pipeline (Phase E concept linking enabler)
+- **Search alias expansion via entity graph:** Entity-graph-augmented retrieval that catches relevant docs neither keyword nor embedding similarity surfaces

--- a/docker-compose.embeddings.yml
+++ b/docker-compose.embeddings.yml
@@ -35,6 +35,7 @@ services:
     container_name: context-library-embeddings
     profiles: [embeddings-gpu]
     restart: always
+    ports: ['8090:80']
     command: --model-id ${EMBEDDING_MODEL:-nomic-ai/nomic-embed-text-v2-moe} --port 80
     volumes:
       - ./data/models:/data
@@ -61,6 +62,7 @@ services:
     container_name: context-library-embeddings
     profiles: [embeddings-cpu]
     restart: always
+    ports: ['8090:80']
     command: --model-id ${EMBEDDING_MODEL:-nomic-ai/nomic-embed-text-v2-moe} --port 80
     volumes:
       - ./data/models:/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zod": "^3.25.0"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
         "@types/node": "^22.13.4",
         "@types/pg": "^8.20.0",
         "tsx": "^4.19.3",
@@ -25,6 +26,37 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -699,9 +731,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,9 +748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -739,9 +765,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,9 +782,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,9 +816,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1823,6 +1837,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2852,6 +2880,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "copy-migrations": "cp -r src/db/migrations dist/db/migrations",
     "start": "node dist/server.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "extract-entities": "tsx scripts/extract-entities.ts"
   },
   "dependencies": {
     "@hono/mcp": "^0.2.4",
@@ -26,6 +27,7 @@
     "path-to-regexp": "8.4.2"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@types/node": "^22.13.4",
     "@types/pg": "^8.20.0",
     "tsx": "^4.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-library",
-  "version": "0.5.4-rc.0",
+  "version": "0.5.4",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/scripts/extract-entities.test.ts
+++ b/scripts/extract-entities.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { mergeEntities } from "./extract-entities.js";
+
+// ── mergeEntities: idempotent merge logic ─────────────────────────
+
+describe("mergeEntities", () => {
+  it("adds new entities to an empty existing list", () => {
+    const fresh = [
+      { canonical_name: "MyProject", scope: "work" as const, aliases: ["proj"], constraints: ["Confidential"] },
+      { canonical_name: "team-lead", scope: "work" as const, aliases: [], constraints: [] },
+    ];
+    const { merged, added, updated, aliasesAdded } = mergeEntities([], fresh);
+    expect(added).toBe(2);
+    expect(updated).toBe(0);
+    expect(aliasesAdded).toBe(0);
+    expect(merged.map((e) => e.canonical_name)).toEqual(["MyProject", "team-lead"]);
+    expect(merged[0].constraints).toEqual(["Confidential"]);
+  });
+
+  it("is idempotent: merging the same fresh set twice yields the same output", () => {
+    const fresh = [
+      { canonical_name: "MyProject", scope: "work" as const, aliases: ["proj"], constraints: ["Confidential"] },
+      { canonical_name: "staging-server", scope: "shared" as const, aliases: ["stage"], constraints: [] },
+    ];
+    const first = mergeEntities([], fresh).merged;
+    const second = mergeEntities(first, fresh);
+    expect(second.added).toBe(0);
+    expect(second.updated).toBe(0);
+    expect(second.aliasesAdded).toBe(0);
+    expect(second.merged).toEqual(first);
+  });
+
+  it("preserves human-edited constraints on existing entities", () => {
+    const existing = [
+      {
+        canonical_name: "MyProject",
+        scope: "work" as const,
+        aliases: ["proj"],
+        constraints: ["Human-added: confidential until launch"],
+      },
+    ];
+    const fresh = [
+      {
+        canonical_name: "MyProject",
+        scope: "work" as const,
+        aliases: ["proj"],
+        constraints: ["LLM-suggested constraint that should NOT replace the human edit"],
+      },
+    ];
+    const { merged } = mergeEntities(existing, fresh);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].constraints).toEqual(["Human-added: confidential until launch"]);
+  });
+
+  it("union-merges aliases case-insensitively, preserving existing casing", () => {
+    const existing = [
+      { canonical_name: "MyProject", scope: "work" as const, aliases: ["Proj"], constraints: [] },
+    ];
+    const fresh = [
+      {
+        canonical_name: "MyProject",
+        scope: "work" as const,
+        aliases: ["proj", "MP", "my-project"],
+        constraints: [],
+      },
+    ];
+    const { merged, added, updated, aliasesAdded } = mergeEntities(existing, fresh);
+    expect(added).toBe(0);
+    expect(updated).toBe(1);
+    expect(aliasesAdded).toBe(2); // "proj" dedupes against "Proj"; MP + my-project add
+    expect(merged[0].aliases).toEqual(["Proj", "MP", "my-project"]);
+  });
+
+  it("never deletes existing entries that do not appear in fresh", () => {
+    const existing = [
+      { canonical_name: "LegacyEntity", scope: "personal" as const, aliases: [], constraints: ["Do not delete"] },
+    ];
+    const fresh = [
+      { canonical_name: "MyProject", scope: "work" as const, aliases: [], constraints: [] },
+    ];
+    const { merged } = mergeEntities(existing, fresh);
+    expect(merged).toHaveLength(2);
+    expect(merged.find((e) => e.canonical_name === "LegacyEntity")).toBeDefined();
+  });
+
+  it("treats canonical_name matching as case-insensitive and preserves existing casing", () => {
+    const existing = [
+      { canonical_name: "MyProject", scope: "work" as const, aliases: ["proj"], constraints: [] },
+    ];
+    const fresh = [
+      { canonical_name: "myproject", scope: "work" as const, aliases: ["MP"], constraints: [] },
+    ];
+    const { merged, added, aliasesAdded } = mergeEntities(existing, fresh);
+    expect(added).toBe(0);
+    expect(aliasesAdded).toBe(1);
+    expect(merged[0].canonical_name).toBe("MyProject");
+    expect(merged[0].aliases).toContain("MP");
+  });
+});

--- a/scripts/extract-entities.ts
+++ b/scripts/extract-entities.ts
@@ -1,0 +1,403 @@
+#!/usr/bin/env tsx
+/**
+ * extract-entities — CLI bootstrap script for entity seeding.
+ *
+ * Reads handoff JSON files from the configured data directory, batches them
+ * to the Anthropic API for entity extraction, and writes a draft
+ * `entities.seed.json` for human review. Idempotent: an existing seed file is
+ * merged — human-edited constraints are preserved, aliases are union-merged,
+ * new entities are added, and existing entries are never deleted.
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... npm run extract-entities
+ *   ANTHROPIC_API_KEY=sk-... npm run extract-entities -- --output ./entities.seed.json
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY  Anthropic API key (required)
+ *   DATA_DIR           Root data dir (default: ./data). Handoffs live in DATA_DIR/handoffs.
+ *   EXTRACT_MODEL      Override model (default: claude-sonnet-4-20250514).
+ *
+ * Notes:
+ *   - This script does NOT run in production. It is a one-shot seeding tool.
+ *   - The @anthropic-ai/sdk is declared as a devDependency to keep the runtime
+ *     image lean. See ROADMAP Horizon: MCP sampling will collapse this into a
+ *     tool and drop the dep entirely.
+ */
+
+import { readdir, readFile, writeFile, access } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Anthropic from "@anthropic-ai/sdk";
+
+const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const BATCH_SIZE = 8;
+
+// ── Types ─────────────────────────────────────────────────────────
+
+type Scope = "work" | "personal" | "shared";
+
+interface EntitySeed {
+  canonical_name: string;
+  scope: Scope;
+  aliases: string[];
+  constraints: string[];
+  confidence?: number;
+}
+
+interface Summary {
+  handoffs_read: number;
+  batches_sent: number;
+  batch_failures: number;
+  entities_total: number;
+  entities_new: number;
+  entities_existing_updated: number;
+  aliases_added: number;
+}
+
+// ── Arg parsing ───────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { output: string } {
+  let output = resolve(process.cwd(), "entities.seed.json");
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--output" || arg === "-o") {
+      const next = argv[i + 1];
+      if (!next) {
+        console.error("Error: --output requires a path argument");
+        process.exit(2);
+      }
+      output = resolve(process.cwd(), next);
+      i++;
+    }
+  }
+  return { output };
+}
+
+// ── File IO ───────────────────────────────────────────────────────
+
+async function readHandoffs(dataDir: string): Promise<Array<{ filename: string; body: unknown }>> {
+  const handoffsDir = join(dataDir, "handoffs");
+  let files: string[];
+  try {
+    files = await readdir(handoffsDir);
+  } catch {
+    console.error(`No handoffs directory at ${handoffsDir} — nothing to extract.`);
+    return [];
+  }
+  const jsonFiles = files
+    .filter((f) => f.endsWith(".json") && !f.startsWith(".tmp-"))
+    .sort();
+
+  const out: Array<{ filename: string; body: unknown }> = [];
+  for (const filename of jsonFiles) {
+    try {
+      const raw = await readFile(join(handoffsDir, filename), "utf8");
+      out.push({ filename, body: JSON.parse(raw) });
+    } catch (err) {
+      console.warn(`[warn] Skipping unreadable handoff ${filename}: ${(err as Error).message}`);
+    }
+  }
+  return out;
+}
+
+async function readExistingSeed(path: string): Promise<EntitySeed[]> {
+  try {
+    await access(path);
+  } catch {
+    return [];
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      console.warn(`[warn] Existing seed at ${path} is not an array — ignoring.`);
+      return [];
+    }
+    return parsed as EntitySeed[];
+  } catch (err) {
+    console.warn(`[warn] Could not parse existing seed at ${path}: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+// ── Merge logic (pure, testable) ──────────────────────────────────
+
+/**
+ * Idempotent merge of freshly extracted entities into an existing seed list.
+ * - New entities are added.
+ * - Existing entities preserve human-edited constraints (constraints are not
+ *   overwritten). Aliases are union-merged. Scope is preserved from the
+ *   existing entry unless the existing entry has no scope set.
+ * - No entry is ever deleted.
+ *
+ * Comparison is case-insensitive on canonical_name.
+ */
+export function mergeEntities(
+  existing: EntitySeed[],
+  fresh: EntitySeed[]
+): { merged: EntitySeed[]; added: number; updated: number; aliasesAdded: number } {
+  const byKey = new Map<string, EntitySeed>();
+  const order: string[] = [];
+
+  for (const e of existing) {
+    const key = e.canonical_name.toLowerCase();
+    byKey.set(key, {
+      canonical_name: e.canonical_name,
+      scope: e.scope,
+      aliases: Array.isArray(e.aliases) ? [...e.aliases] : [],
+      constraints: Array.isArray(e.constraints) ? [...e.constraints] : [],
+      ...(typeof e.confidence === "number" ? { confidence: e.confidence } : {}),
+    });
+    order.push(key);
+  }
+
+  let added = 0;
+  let updated = 0;
+  let aliasesAdded = 0;
+
+  for (const f of fresh) {
+    const key = f.canonical_name.toLowerCase();
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, {
+        canonical_name: f.canonical_name,
+        scope: f.scope,
+        aliases: Array.isArray(f.aliases) ? [...new Set(f.aliases)] : [],
+        constraints: Array.isArray(f.constraints) ? [...f.constraints] : [],
+        ...(typeof f.confidence === "number" ? { confidence: f.confidence } : {}),
+      });
+      order.push(key);
+      added++;
+      continue;
+    }
+
+    // Union-merge aliases (case-insensitive dedupe, preserve existing casing)
+    const seen = new Set(current.aliases.map((a) => a.toLowerCase()));
+    let changed = false;
+    for (const alias of f.aliases ?? []) {
+      if (!seen.has(alias.toLowerCase())) {
+        current.aliases.push(alias);
+        seen.add(alias.toLowerCase());
+        aliasesAdded++;
+        changed = true;
+      }
+    }
+
+    // Preserve existing constraints. Never overwrite or append fresh
+    // constraints — humans curate those. (New entities get fresh constraints
+    // because there is nothing to preserve yet.)
+    if (changed) updated++;
+  }
+
+  const merged = order.map((k) => byKey.get(k)!);
+  return { merged, added, updated, aliasesAdded };
+}
+
+// ── Prompting ─────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are extracting canonical entities from operational handoff data.
+
+Return ONLY a JSON array. Each element MUST have this exact shape:
+{
+  "canonical_name": string,
+  "scope": "work" | "personal" | "shared",
+  "aliases": string[],
+  "constraints": string[],
+  "confidence": number  // 0.0 to 1.0
+}
+
+Rules:
+- canonical_name: the preferred, unambiguous form of the entity.
+- scope: "work" if the entity belongs to a professional/employer context, "personal" for private/home/individual context, "shared" if it legitimately spans both.
+- aliases: other names or informal references seen in the handoffs.
+- constraints: short guidance on how to handle the entity (e.g. confidentiality, device ownership). Leave as [] if none are evident.
+- confidence: your confidence that this is a real, stable entity worth tracking.
+
+Only extract entities that are actually named and recurring. Do NOT invent entities.
+Do NOT include any commentary, markdown fences, or prose — just the JSON array.
+
+Example shape (generic placeholders — do not copy these as real entities):
+[
+  {"canonical_name": "MyProject", "scope": "work", "aliases": ["proj"], "constraints": ["Confidential"], "confidence": 0.9},
+  {"canonical_name": "team-lead", "scope": "work", "aliases": [], "constraints": [], "confidence": 0.7},
+  {"canonical_name": "staging-server", "scope": "shared", "aliases": ["stage"], "constraints": ["Shared with other teams"], "confidence": 0.6}
+]`;
+
+function buildUserMessage(batch: Array<{ filename: string; body: unknown }>): string {
+  const lines: string[] = [
+    "Extract canonical entities from the following handoff files.",
+    "Each file is presented as `--- <filename> ---` followed by its JSON body.",
+    "",
+  ];
+  for (const { filename, body } of batch) {
+    lines.push(`--- ${filename} ---`);
+    lines.push(JSON.stringify(body, null, 2));
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function parseModelOutput(raw: string): EntitySeed[] {
+  // Strip fences if the model ignored instructions and wrapped the JSON.
+  const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+  const parsed = JSON.parse(trimmed);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Model output was not a JSON array");
+  }
+  const validated: EntitySeed[] = [];
+  for (const row of parsed) {
+    if (
+      row &&
+      typeof row === "object" &&
+      typeof row.canonical_name === "string" &&
+      (row.scope === "work" || row.scope === "personal" || row.scope === "shared")
+    ) {
+      validated.push({
+        canonical_name: row.canonical_name,
+        scope: row.scope,
+        aliases: Array.isArray(row.aliases)
+          ? row.aliases.filter((a: unknown) => typeof a === "string")
+          : [],
+        constraints: Array.isArray(row.constraints)
+          ? row.constraints.filter((c: unknown) => typeof c === "string")
+          : [],
+        ...(typeof row.confidence === "number" ? { confidence: row.confidence } : {}),
+      });
+    }
+  }
+  return validated;
+}
+
+// ── Orchestration ─────────────────────────────────────────────────
+
+async function extractBatch(
+  client: Anthropic,
+  model: string,
+  batch: Array<{ filename: string; body: unknown }>
+): Promise<EntitySeed[]> {
+  const response = await client.messages.create({
+    model,
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: buildUserMessage(batch) }],
+  });
+
+  const textBlock = response.content.find((b) => b.type === "text");
+  if (!textBlock || textBlock.type !== "text") {
+    throw new Error("Model response contained no text block");
+  }
+  return parseModelOutput(textBlock.text);
+}
+
+async function run(): Promise<number> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error("Error: ANTHROPIC_API_KEY is not set.");
+    return 2;
+  }
+
+  const { output } = parseArgs(process.argv.slice(2));
+  const dataDir = resolve(process.cwd(), process.env.DATA_DIR ?? "./data");
+  const model = process.env.EXTRACT_MODEL ?? DEFAULT_MODEL;
+
+  console.log(`[extract-entities] data dir: ${dataDir}`);
+  console.log(`[extract-entities] output:   ${output}`);
+  console.log(`[extract-entities] model:    ${model}`);
+
+  const handoffs = await readHandoffs(dataDir);
+  if (handoffs.length === 0) {
+    console.log("No handoffs to process — exiting.");
+    return 0;
+  }
+
+  const existing = await readExistingSeed(output);
+  const client = new Anthropic({ apiKey });
+
+  const summary: Summary = {
+    handoffs_read: handoffs.length,
+    batches_sent: 0,
+    batch_failures: 0,
+    entities_total: existing.length,
+    entities_new: 0,
+    entities_existing_updated: 0,
+    aliases_added: 0,
+  };
+
+  // Accumulate across batches so we de-dupe before we merge with the existing
+  // seed file. This avoids double-counting when two batches surface the same
+  // entity.
+  const freshByKey = new Map<string, EntitySeed>();
+
+  for (let i = 0; i < handoffs.length; i += BATCH_SIZE) {
+    const batch = handoffs.slice(i, i + BATCH_SIZE);
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(handoffs.length / BATCH_SIZE);
+    console.log(`[extract-entities] batch ${batchNum}/${totalBatches} (${batch.length} files)`);
+
+    summary.batches_sent++;
+    try {
+      const extracted = await extractBatch(client, model, batch);
+      for (const e of extracted) {
+        const key = e.canonical_name.toLowerCase();
+        const cur = freshByKey.get(key);
+        if (!cur) {
+          freshByKey.set(key, {
+            ...e,
+            aliases: [...new Set(e.aliases)],
+          });
+        } else {
+          const seen = new Set(cur.aliases.map((a) => a.toLowerCase()));
+          for (const alias of e.aliases) {
+            if (!seen.has(alias.toLowerCase())) {
+              cur.aliases.push(alias);
+              seen.add(alias.toLowerCase());
+            }
+          }
+          if (typeof e.confidence === "number" && typeof cur.confidence === "number") {
+            cur.confidence = Math.max(cur.confidence, e.confidence);
+          }
+        }
+      }
+    } catch (err) {
+      summary.batch_failures++;
+      console.warn(`[extract-entities] batch ${batchNum} failed: ${(err as Error).message}`);
+      // Continue with remaining batches
+    }
+  }
+
+  const fresh = Array.from(freshByKey.values());
+  const { merged, added, updated, aliasesAdded } = mergeEntities(existing, fresh);
+
+  summary.entities_total = merged.length;
+  summary.entities_new = added;
+  summary.entities_existing_updated = updated;
+  summary.aliases_added = aliasesAdded;
+
+  await writeFile(output, JSON.stringify(merged, null, 2) + "\n", "utf8");
+
+  console.log("");
+  console.log("[extract-entities] summary");
+  console.log(`  handoffs read:                 ${summary.handoffs_read}`);
+  console.log(`  batches sent:                  ${summary.batches_sent}`);
+  console.log(`  batch failures:                ${summary.batch_failures}`);
+  console.log(`  entities total (after merge):  ${summary.entities_total}`);
+  console.log(`  entities new:                  ${summary.entities_new}`);
+  console.log(`  entities updated (aliases):    ${summary.entities_existing_updated}`);
+  console.log(`  aliases added:                 ${summary.aliases_added}`);
+  console.log(`  output:                        ${output}`);
+
+  return summary.batch_failures > 0 ? 1 : 0;
+}
+
+// Only run when invoked directly, not when imported by tests.
+const thisFile = fileURLToPath(import.meta.url);
+const invokedAsScript = process.argv[1] && resolve(process.argv[1]) === thisFile;
+if (invokedAsScript) {
+  run().then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error("[extract-entities] fatal:", err);
+      process.exit(1);
+    }
+  );
+}

--- a/src/__tests__/entities.test.ts
+++ b/src/__tests__/entities.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   computeEnvelope,
   emptyEnvelope,
   generateBoundaryNotice,
+  lookupEntities,
   type EntityInfo,
 } from "../tools/entities.js";
+
+// Mock the DB client to avoid real Postgres for unit tests.
+const queryMock = vi.fn();
+vi.mock("../db/client.js", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+}));
 
 // ── Test fixtures (generic names only — no personal data) ─────────
 
@@ -144,5 +151,96 @@ describe("generateBoundaryNotice", () => {
     const notice = generateBoundaryNotice(env)!;
     // personal scope has no constraints — should not appear as "Constraints from personal scope:"
     expect(notice).not.toContain("Constraints from personal scope:");
+  });
+});
+
+// ── lookupEntities: last_referenced bookkeeping ───────────────────
+
+describe("lookupEntities — last_referenced update", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it("issues a batched UPDATE on entities.last_referenced when matches are found", async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.startsWith("SELECT")) {
+        return Promise.resolve({
+          rows: [
+            {
+              canonical_name: "Project Alpha",
+              scope: "work",
+              aliases: ["alpha"],
+              constraints: [],
+            },
+            {
+              canonical_name: "Home Server",
+              scope: "personal",
+              aliases: ["NAS"],
+              constraints: [],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const matched = await lookupEntities(["Working on Project Alpha today"]);
+    expect(matched.map((e) => e.canonical_name)).toEqual(["Project Alpha"]);
+
+    const updateCall = queryMock.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE entities")
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0]).toContain("last_referenced = NOW()");
+    expect(updateCall![0]).toContain("canonical_name = ANY($1)");
+    expect(updateCall![1]).toEqual([["Project Alpha"]]);
+  });
+
+  it("does not issue an UPDATE when no entities match", async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.startsWith("SELECT")) {
+        return Promise.resolve({
+          rows: [
+            {
+              canonical_name: "Project Alpha",
+              scope: "work",
+              aliases: ["alpha"],
+              constraints: [],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const matched = await lookupEntities(["Totally unrelated text about cats"]);
+    expect(matched).toEqual([]);
+
+    const updateCall = queryMock.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE entities")
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it("swallows UPDATE failures (bookkeeping must not break search)", async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.startsWith("SELECT")) {
+        return Promise.resolve({
+          rows: [
+            {
+              canonical_name: "Project Alpha",
+              scope: "work",
+              aliases: [],
+              constraints: [],
+            },
+          ],
+        });
+      }
+      // UPDATE fails
+      return Promise.reject(new Error("db offline"));
+    });
+
+    const matched = await lookupEntities(["Project Alpha notes"]);
+    expect(matched.map((e) => e.canonical_name)).toEqual(["Project Alpha"]);
   });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -653,6 +653,17 @@ describe("MCP Tools", () => {
       expect(retrieved.handoff_count).toBeGreaterThan(0);
       expect(Number.isInteger(retrieved.handoff_count)).toBe(true);
     });
+
+    it("evidence_pulled is true when a handoff is successfully loaded", async () => {
+      await storeAndVerify({ tone_notes: "evidence_pulled test" });
+
+      const getRes = await mcpPost(
+        jsonrpc("tools/call", { name: "get_latest_handoff", arguments: {} })
+      );
+      const getData = (await parseSseResponse(getRes)) as any;
+      const retrieved = JSON.parse(getData.result.content[0].text);
+      expect(retrieved.evidence_pulled).toBe(true);
+    });
   });
 
   // ────────────────────────────────────────────────

--- a/src/storage/schemas.ts
+++ b/src/storage/schemas.ts
@@ -10,7 +10,7 @@ export const HandoffSchema = z
         mood: z.string().optional(),
       })
       .optional(),
-    active_context: z.record(z.string(), z.any()).optional(),
+    active_context: z.record(z.string(), z.unknown()).optional(),
     tasks: z
       .object({
         completed: z.array(z.string()).optional(),

--- a/src/tools/entities.ts
+++ b/src/tools/entities.ts
@@ -49,6 +49,10 @@ export function emptyEnvelope(): ContextEnvelope {
  * Look up entities that appear in the given texts.
  * Matches case-insensitively against canonical_name and aliases.
  * Returns empty array if DB is unavailable (graceful degradation).
+ *
+ * Side effect: when entities are matched, their `last_referenced` column is
+ * updated to NOW() via a single batched UPDATE. Failures are swallowed —
+ * bookkeeping must never fail an active search.
  */
 export async function lookupEntities(texts: string[]): Promise<EntityInfo[]> {
   if (texts.length === 0) return [];
@@ -85,6 +89,17 @@ export async function lookupEntities(texts: string[]): Promise<EntityInfo[]> {
           aliases: row.aliases || [],
           constraints: row.constraints || [],
         });
+      }
+    }
+
+    if (matched.length > 0) {
+      try {
+        await queryFn(
+          "UPDATE entities SET last_referenced = NOW() WHERE canonical_name = ANY($1)",
+          [matched.map((e) => e.canonical_name)]
+        );
+      } catch {
+        // Non-fatal — bookkeeping failure must not break search
       }
     }
 

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -198,15 +198,25 @@ Parameters:
   - tone_notes (optional): Guidance for the next instance on how to approach the user
   - timezone (optional): IANA timezone identifier (e.g., 'America/New_York')
 
-Returns: {success, stored_at, filename, task_summary, schema_version}`;
+Returns: {success, stored_at, filename, task_summary, schema_version}
+
+Response Format:
+- Reasoning-capable models (Claude Opus, o1, Gemini with thinking): Use structured reflection before confirming the store. Evaluate whether the captured state reflects the actual session. Note any gaps in active_context or tasks explicitly.
+- Standard models (Claude Sonnet/Haiku, GPT-4.x, Gemini Flash): Respond directly. Confirm the store and summarize task_summary. Flag when captured state seems thin.`;
 
 const GET_LATEST_HANDOFF_DESCRIPTION = `Retrieve the most recent handoff state. Returns operational context, active work, task lists, and tone notes from the last session.
 
 WHEN TO CALL: At session start (always), before any store_handoff or patch_handoff (to load current state), and before any evaluative or judgment-class response (to ground reasoning in recorded context, not inference alone).
 
-Pre-computed fields: elapsed_seconds, same_calendar_day (if false, operational_state is stale — confirm with user), task_summary, applied_scope/filtered_fields, schema_version, handoff_count, stored_at_local.
+Pre-computed fields: elapsed_seconds, same_calendar_day (if false, operational_state is stale — confirm with user), task_summary, applied_scope/filtered_fields, schema_version, handoff_count, stored_at_local, evidence_pulled.
 
-Response shape: operational_state, active_context, tasks, task_summary, tone_notes (read before responding), timezone, stored_at, retrieved_at, elapsed_seconds, same_calendar_day, schema_version, handoff_count.
+Response shape: operational_state, active_context, tasks, task_summary, tone_notes (read before responding), timezone, stored_at, retrieved_at, elapsed_seconds, same_calendar_day, schema_version, handoff_count, evidence_pulled.
+
+SessionEvidence:
+evidence_pulled indicates whether operational context was successfully loaded.
+When false, judgment-class responses (career advice, strategic decisions,
+relationship guidance) should note that they lack session history context.
+This is advisory — the model decides how to weight the signal.
 
 Parameters:
 - scope (optional, default "full"): "full" | "work" | "personal"
@@ -238,7 +248,11 @@ Parameters:
   - tone_notes (optional): String to replace, or null to preserve
   - timezone (optional): IANA timezone string to replace, or null to preserve
 
-Returns: {success, patched_fields, stored_at, source_handoff, task_summary, schema_version}`;
+Returns: {success, patched_fields, stored_at, source_handoff, task_summary, schema_version}
+
+Response Format:
+- Reasoning-capable models (Claude Opus, o1, Gemini with thinking): Use structured reflection before patching. Evaluate whether the patch is consistent with the loaded state. Note any gaps or conflicts explicitly.
+- Standard models (Claude Sonnet/Haiku, GPT-4.x, Gemini Flash): Respond directly. Confirm the patched_fields and updated task_summary. Flag when the patch seems inconsistent with recent context.`;
 
 // ── Zod Schemas for patch_handoff ──────────────────────────────────
 
@@ -266,7 +280,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
           mood: z.string().optional(),
         })
         .optional(),
-      active_context: z.record(z.string(), z.any()).optional(),
+      active_context: z.record(z.string(), z.unknown()).optional(),
       tasks: z
         .object({
           completed: z.array(z.string()).optional(),
@@ -342,6 +356,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
                 error: true,
                 message: "No handoff stored yet",
                 code: "NOT_FOUND",
+                evidence_pulled: false,
               }),
             },
           ],
@@ -357,6 +372,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
                 error: true,
                 message: "No handoff stored yet",
                 code: "NOT_FOUND",
+                evidence_pulled: false,
               }),
             },
           ],
@@ -382,6 +398,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
               stored_at_local: formatStoredAtLocal(handoff.stored_at ?? "", handoff.timezone),
               schema_version: SCHEMA_VERSION,
               handoff_count: handoffCount,
+              evidence_pulled: true,
             }),
           },
         ],
@@ -399,7 +416,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
         .nullable()
         .optional(),
       active_context: z
-        .record(z.string(), z.any())
+        .record(z.string(), z.unknown())
         .nullable()
         .optional(),
       tasks: z

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -81,7 +81,11 @@ READ context_envelope FIRST. If boundary_detected=true or constraint_alerts non-
 
 Returns: {results[], context_envelope, query, total, mode, deduplicated, pre_dedup_count}
 
-If results reference events indirectly, reformulate with specific terms, lower threshold (0.05), higher limit (20).`;
+If results reference events indirectly, reformulate with specific terms, lower threshold (0.05), higher limit (20).
+
+Response Format:
+- Reasoning-capable models (Claude Opus, o1, Gemini with thinking): Use structured reflection before synthesizing results. Evaluate whether retrieved evidence actually supports the user's question. Note gaps explicitly when results are thin or off-topic.
+- Standard models (Claude Sonnet/Haiku, GPT-4.x, Gemini Flash): Respond directly using available results. Flag when results seem insufficient and suggest query reformulation.`;
 
 const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs and tasks. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
 


### PR DESCRIPTION
## Summary

- **evidence_pulled advisory + per-model response format** — `get_latest_handoff` now reports whether context was loaded (advisory, not blocking); `store_handoff`, `patch_handoff`, and `search_context` tool descriptions gain two-tier Response Format guidance for reasoning-capable vs standard models.
- **extract-entities CLI** — new `scripts/extract-entities.ts` bootstrap tool that batches handoffs to the Anthropic API and writes a draft `entities.seed.json` with idempotent merge (preserves human-edited constraints, union-merges aliases, never deletes). `@anthropic-ai/sdk` added as a devDependency.
- **last_referenced population** — `entities.last_referenced` is now updated to `NOW()` via a single batched UPDATE on entity match in `lookupEntities`. Failures swallowed so bookkeeping never breaks search.
- **z.any() → z.unknown() migration** — stricter type safety in HandoffSchema and handoff tool parameters.
- **TEI port mapping** — `ports: ['8090:80']` added to both `embeddings-gpu` and `embeddings-cpu` for externalized deployments.
- **ROADMAP rewrite** — versioned completed buckets, v0.5.4 current, v0.6 resilience, v0.7 new primitives, Horizon list.
- **Release** — 0.5.4-rc.0 → 0.5.4. No git tag created (manual operator action).

## Test plan

- [x] `npm test` passes (92 passed, 29 Postgres-gated skips)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] New tests: `evidence_pulled` round-trip in `server.test.ts`; `last_referenced` UPDATE behavior (match, no-match, failure) in `entities.test.ts`; 6 `mergeEntities` unit tests in `scripts/extract-entities.test.ts`
- [ ] After merge: operator tags `v0.5.4` manually to trigger release pipeline

## Personal Data Audit

All committed files use generic placeholders only (MyProject, team-lead, staging-server, Project Alpha, Home Server, Work Laptop). `.claude/settings.local.json` added to `.gitignore` — it contained machine-local paths and was never staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)