### PR TITLE
feat: add cloudflared to auth compose layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,13 @@ EMBEDDING_DIMENSIONS=768
 # ALLOWED_USERS=user@example.com
 # EXTERNAL_URL=https://context-library.example.com
 
+# Cloudflare Tunnel token for the named tunnel that routes to this deployment.
+# Create a tunnel in the Cloudflare dashboard (Zero Trust → Networks → Tunnels),
+# configure its public hostname to point to https://mcp-auth-proxy:443,
+# then paste the tunnel token here. The cloudflared container reads this as
+# TUNNEL_TOKEN directly, matching the variable name used by the image.
+# TUNNEL_TOKEN=
+
 # ── Notifications ────────────────────────────────────────
 # Push notification URL for CI/CD pipeline events.
 # Default: https://ntfy.sh/context-library-ci (public ntfy instance)

--- a/README.md
+++ b/README.md
@@ -227,15 +227,23 @@ curl http://localhost:3100/health
 
 ## External Access with Auth Proxy
 
-To expose Context Library to the internet (required for Claude.ai and other hosted MCP clients), you need two things: an OAuth proxy and a tunnel or reverse proxy.
+To expose Context Library to the internet (required for Claude.ai and other hosted MCP clients), use the auth compose overlay. It bundles [mcp-auth-proxy](https://github.com/sigbit/mcp-auth-proxy) (OAuth 2.1 gateway) and a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) connector so the full ingress chain is managed as a single stack:
+
+```
+Internet → cloudflared → mcp-auth-proxy:443 → context-library:3100
+```
 
 ### Auth Proxy Setup
 
-The included `docker-compose.auth.yml` adds [mcp-auth-proxy](https://github.com/sigbit/mcp-auth-proxy) as an OAuth 2.1 gateway.
-
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.auth.yml up -d
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.postgres.yml \
+  -f docker-compose.auth.yml \
+  up -d
 ```
+
+For deployments that also need embeddings, add `-f docker-compose.embeddings.yml --profile embeddings-cpu` (or `embeddings-gpu`).
 
 **Required setup:**
 
@@ -255,35 +263,15 @@ docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-co
 3. **Client Registration Data:**
    Once MCP clients (Claude.ai, Claude Desktop, etc.) authenticate through the proxy, their OAuth client registrations are stored in `./proxy-data/`. This directory must be preserved across deployments — losing it means all connected clients will need to re-register.
 
-### Tunnel / Reverse Proxy
+### Cloudflare Tunnel
 
-Context Library does not include a tunnel in the public compose files — tunnel configuration is deployment-specific. Here's an example using Cloudflare Tunnel:
+The `cloudflared` service in `docker-compose.auth.yml` uses named-tunnel (token) mode — routing is configured in the Cloudflare dashboard, not in local files. To wire up a deployment:
 
-```yaml
-# docker-compose.cloudflared.yml (deployment-specific, not committed)
-services:
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    container_name: context-library-tunnel
-    restart: unless-stopped
-    command: tunnel run
-    environment:
-      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
-    depends_on:
-      - mcp-auth-proxy
-```
+1. In the Cloudflare dashboard, go to **Zero Trust → Networks → Tunnels** and create a new tunnel.
+2. Configure the tunnel's public hostname to point to `https://mcp-auth-proxy:443` — this works because `cloudflared` runs on the same Docker network as the proxy and resolves the service name directly (no host IP needed).
+3. Copy the tunnel token from the dashboard into `TUNNEL_TOKEN` in your `.env`.
 
-Start with:
-```bash
-docker compose \
-  -f docker-compose.yml \
-  -f docker-compose.postgres.yml \
-  -f docker-compose.auth.yml \
-  -f docker-compose.cloudflared.yml \
-  up -d
-```
-
-> **Note:** When using `TUNNEL_TOKEN`, the tunnel configuration is managed in the Cloudflare dashboard, not in a local config file. The dashboard config takes precedence. Point the tunnel's public hostname to `https://mcp-auth-proxy:443`.
+Because routing lives in the dashboard, domain names and tunnel IDs stay out of the repo. `cloudflared` makes outbound-only connections to Cloudflare's edge, so no inbound ports need to be published on the host.
 
 ## Release Workflow
 
@@ -439,6 +427,7 @@ See `.env.example` for all configuration options.
 | `AUTH0_CLIENT_SECRET` | OAuth client secret |
 | `ALLOWED_USERS` | Comma-separated list of authorized email addresses |
 | `EXTERNAL_URL` | Public-facing URL (e.g., `https://your-domain.com`) |
+| `TUNNEL_TOKEN` | Cloudflare named-tunnel token (routing configured in the Cloudflare dashboard) |
 
 ## License
 

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -1,12 +1,17 @@
-# OAuth 2.1 authentication via mcp-auth-proxy
+# OAuth 2.1 authentication via mcp-auth-proxy + Cloudflare Tunnel ingress.
 # Required for exposing Context Library to the internet.
-# Requires an OIDC provider (Auth0, Google, etc.)
+# Requires an OIDC provider (Auth0, Google, etc.) and a named Cloudflare
+# Tunnel whose public hostname routes to https://mcp-auth-proxy:443.
 # See README.md for configuration details.
+#
+# Full ingress chain managed by this stack:
+#   Internet → cloudflared → mcp-auth-proxy:443 → context-library:3100
 
 services:
   mcp-auth-proxy:
-    # No ports published — requires a tunnel or reverse proxy for external access.
-    # See README for Cloudflare Tunnel example.
+    # No ports published — cloudflared (same compose network) routes
+    # traffic to this service via its public hostname configured in the
+    # Cloudflare dashboard.
     image: ghcr.io/sigbit/mcp-auth-proxy:latest
     container_name: mcp-auth-proxy
     restart: unless-stopped
@@ -31,6 +36,21 @@ services:
       - ./proxy-certs:/certs:ro
     expose:
       - "443"
+
+  # Cloudflare Tunnel connector. Uses named-tunnel (token) mode —
+  # hostname-to-service routing is configured in the Cloudflare dashboard,
+  # not in a local config file. This keeps domain names and tunnel IDs
+  # out of committed files. depends_on ensures the proxy is up before the
+  # tunnel starts routing traffic.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: context-library-tunnel
+    restart: unless-stopped
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+    depends_on:
+      - mcp-auth-proxy
 
   context-library:
     expose:


### PR DESCRIPTION
## Summary

- Bring the Cloudflare Tunnel connector into `docker-compose.auth.yml` so the full ingress chain — `Internet → cloudflared → mcp-auth-proxy:443 → context-library:3100` — is managed as a single compose stack.
- Previously the tunnel ran as a host-level process outside the stack, which allowed two failure modes: the tunnel could silently bypass auth by pointing directly at `context-library:3100`, and `docker compose down` would leave the tunnel alive against a dead (or newly-restarted, unauthenticated) service.
- Uses named-tunnel (token) mode — hostname routing lives in the Cloudflare dashboard, so no `config.yml`, domain names, or tunnel IDs in the repo.
- `depends_on: mcp-auth-proxy` ensures the proxy is up before the tunnel starts accepting traffic.
- Env var is `TUNNEL_TOKEN` — the same name the `cloudflared` image reads internally, no wrapper indirection.

## Files

- [docker-compose.auth.yml](../blob/feature/cloudflared-compose/docker-compose.auth.yml) — new `cloudflared` service; header comment documents the full chain.
- [.env.example](../blob/feature/cloudflared-compose/.env.example) — `TUNNEL_TOKEN` added under the Auth Proxy section with dashboard-setup comment.
- [README.md](../blob/feature/cloudflared-compose/README.md) — replace the deployment-specific `cloudflared.yml` example with a short Cloudflare Tunnel section pointing at the bundled service; deployment command updated; embeddings-overlay hint added; env-var table row added.

## Test plan

- [x] No application code changes, no tests needed
- [x] PII audit clean — only generic placeholders (`your-domain.com`, `mcp-auth-proxy:443`)
- [ ] Operator deploys with `TUNNEL_TOKEN` set in `.env` and verifies `Internet → cloudflared → mcp-auth-proxy → context-library` routes end-to-end
- [ ] Operator verifies `docker compose down` tears down cloudflared + proxy together

🤖 Generated with [Claude Code](https://claude.com/claude-code)