### PR TITLE
feat: v0.6 Knowledge layer — notes table + MCP tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,10 +53,11 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - Tool description updates for new capabilities
 - Version bump to 0.5.4
 
-## Next: v0.6 — Resilience & Retrieval
+## Next: v0.6 — Resilience, Retrieval & Knowledge
 
-Focus: make the system self-healing, observable, and harder to misuse.
+Focus: make the system self-healing, observable, harder to misuse — and introduce the third primitive.
 
+- **Knowledge layer (third primitive):** `notes` table in PostgreSQL with MCP tools (`create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note`); embedded into pgvector for unified semantic search; `'note'` added to `search_context` `content_types`; distinct from artifacts — knowledge is interpretation, not output
 - **Embedding resilience:** `embedding_status` field in `get_latest_handoff` response (TEI health + pending count); pending embeddings queue with dead-letter pattern for TEI outage recovery (O(k) recovery vs O(n) full reindex)
 - **Handoff navigation:** `list_handoffs` and `get_handoff` MCP tools for historical handoff browsing and retrieval
 - **Dynamic task summary:** Server-side computed task summary in `get_latest_handoff` — critical items, due this week, recently completed, blocked chains (replaces basic counts)
@@ -67,9 +68,8 @@ Focus: make the system self-healing, observable, and harder to misuse.
 
 ## Future: v0.7 — New Primitives
 
-Focus: expand beyond handoffs and tasks into permanent knowledge and richer structure.
+Focus: expand beyond the three primitives into richer structure and artifact storage.
 
-- **Knowledge layer (third primitive):** `notes` table in PostgreSQL with MCP tools (`create_note`, `search_notes`, `list_notes`, `get_note`); embedded into pgvector for unified semantic search; distinct from artifacts — knowledge is interpretation, not output
 - **Artifact storage:** File/content tracking with metadata, SHA-256 hashing, and versioning; prompt library via tagging convention
 - **Task schema evolution:** Subtasks (parent_id), relations (blocks/blocked-by/related), custom fields (JSONB UDAs); hierarchy is opt-in, flat tasks remain the default
 - **Bitemporal entity constraints:** `valid_from`/`valid_until` on entities to prevent stale constraint application

--- a/src/__tests__/notes.test.ts
+++ b/src/__tests__/notes.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Note tool integration tests.
+ *
+ * Requires a running PostgreSQL instance. See tasks.test.ts for setup.
+ * If Postgres is not available, the entire suite is skipped gracefully.
+ */
+
+const TEST_PORT = 3196;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_DATA_DIR = join(process.cwd(), "data", "test-notes");
+
+const PG_DATABASE = "cl_test_notes";
+const PG_USER = process.env.PGUSER ?? "cl";
+const PG_PASSWORD = process.env.PGPASSWORD ?? "test";
+const PG_HOST = process.env.PGHOST ?? "localhost";
+const PG_PORT = process.env.PGPORT ?? "5432";
+
+let serverProcess: ChildProcess;
+
+async function waitForServer(url: string, timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${url}/health`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Server did not start within ${timeoutMs}ms`);
+}
+
+async function parseSseResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  const dataLine = text.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`No data line in SSE response. Body:\n${text}`);
+  return JSON.parse(dataLine.slice(5).trim());
+}
+
+function jsonrpc(method: string, params?: Record<string, unknown>, id = 1) {
+  return { jsonrpc: "2.0", method, ...(params ? { params } : {}), id };
+}
+
+async function mcpPost(body: unknown) {
+  return fetch(`${BASE_URL}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream, application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callTool(name: string, args: Record<string, unknown> = {}) {
+  const res = await mcpPost(jsonrpc("tools/call", { name, arguments: args }));
+  expect(res.status).toBe(200);
+  const data = (await parseSseResponse(res)) as any;
+  return JSON.parse(data.result.content[0].text);
+}
+
+async function checkPostgres(): Promise<boolean> {
+  try {
+    const pg = await import("pg");
+
+    // Ensure the test database exists — connect to default 'postgres' first.
+    const admin = new pg.default.Client({
+      host: PG_HOST,
+      port: parseInt(PG_PORT),
+      user: PG_USER,
+      password: PG_PASSWORD,
+      database: "postgres",
+    });
+    await admin.connect();
+    const exists = await admin.query(
+      "SELECT 1 FROM pg_database WHERE datname = $1",
+      [PG_DATABASE]
+    );
+    if (exists.rowCount === 0) {
+      await admin.query(`CREATE DATABASE ${PG_DATABASE}`);
+    }
+    await admin.end();
+
+    const client = new pg.default.Client({
+      host: PG_HOST,
+      port: parseInt(PG_PORT),
+      user: PG_USER,
+      password: PG_PASSWORD,
+      database: PG_DATABASE,
+    });
+    await client.connect();
+
+    // Clean slate for test isolation
+    await client.query("DROP TABLE IF EXISTS notes CASCADE");
+    await client.query("DROP TABLE IF EXISTS tasks CASCADE");
+    await client.query("DROP TABLE IF EXISTS embeddings CASCADE");
+    await client.query("DROP TABLE IF EXISTS _migrations CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_status CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_scope CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_priority CASCADE");
+
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const pgAvailable = await checkPostgres();
+
+if (!pgAvailable) {
+  console.log("\n" + "=".repeat(60));
+  console.log("  NOTICE: PostgreSQL not available");
+  console.log("  Note Tools suite will be SKIPPED");
+  console.log("=".repeat(60) + "\n");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────
+
+describe.skipIf(!pgAvailable)("Note Tools", () => {
+  beforeAll(async () => {
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+    await mkdir(TEST_DATA_DIR, { recursive: true });
+
+    serverProcess = spawn("npx", ["tsx", "src/server.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MCP_PORT: String(TEST_PORT),
+        DATA_DIR: TEST_DATA_DIR,
+        PGHOST: PG_HOST,
+        PGPORT: PG_PORT,
+        PGUSER: PG_USER,
+        PGPASSWORD: PG_PASSWORD,
+        PGDATABASE: PG_DATABASE,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: true,
+    });
+
+    // Uncomment for debugging:
+    // serverProcess.stderr?.on("data", (d) => process.stderr.write(d));
+    // serverProcess.stdout?.on("data", (d) => process.stdout.write(d));
+
+    await waitForServer(BASE_URL);
+  }, 20_000);
+
+  afterAll(async () => {
+    if (serverProcess) {
+      serverProcess.kill("SIGTERM");
+      await new Promise((r) => setTimeout(r, 500));
+      if (!serverProcess.killed) serverProcess.kill("SIGKILL");
+    }
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  it("note tools appear in tools/list", async () => {
+    const res = await mcpPost(jsonrpc("tools/list"));
+    const data = (await parseSseResponse(res)) as any;
+    const toolNames: string[] = data.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain("create_note");
+    expect(toolNames).toContain("get_note");
+    expect(toolNames).toContain("list_notes");
+    expect(toolNames).toContain("search_notes");
+    expect(toolNames).toContain("update_note");
+    expect(toolNames).toContain("delete_note");
+  });
+
+  describe("create_note", () => {
+    it("creates a note with all fields and returns id + title + created_at", async () => {
+      const result = await callTool("create_note", {
+        title: "Decision: use pgvector over FAISS",
+        content: "After evaluating both, chose pgvector because the Postgres integration eliminates a separate service.",
+        scope: "work",
+        domain: "architecture",
+        tags: ["embeddings", "infra"],
+        source_url: "https://example.com/pgvector",
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.id).toBeDefined();
+      expect(result.title).toBe("Decision: use pgvector over FAISS");
+      expect(result.created_at).toBeDefined();
+    });
+
+    it("creates a minimal note with just title, content, scope", async () => {
+      const result = await callTool("create_note", {
+        title: "Minimal knowledge entry",
+        content: "The smallest viable note.",
+        scope: "personal",
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.id).toBeDefined();
+    });
+
+    it("returns validation error for empty title", async () => {
+      const result = await callTool("create_note", {
+        title: "",
+        content: "content",
+        scope: "personal",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns validation error for empty content", async () => {
+      const result = await callTool("create_note", {
+        title: "title",
+        content: "",
+        scope: "personal",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("get_note", () => {
+    it("retrieves a note with full content by ID", async () => {
+      const created = await callTool("create_note", {
+        title: "Note to retrieve",
+        content: "The full body of the note.",
+        scope: "shared",
+        domain: "testing",
+      });
+
+      const result = await callTool("get_note", { id: created.id });
+      expect(result.id).toBe(created.id);
+      expect(result.title).toBe("Note to retrieve");
+      expect(result.content).toBe("The full body of the note.");
+      expect(result.scope).toBe("shared");
+      expect(result.domain).toBe("testing");
+    });
+
+    it("returns NOT_FOUND for non-existent ID", async () => {
+      const result = await callTool("get_note", {
+        id: "00000000-0000-0000-0000-000000000000",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("list_notes", () => {
+    it("returns metadata only — not full content", async () => {
+      await callTool("create_note", {
+        title: "List test note",
+        content: "This content should NOT appear in list output.",
+        scope: "personal",
+      });
+
+      const result = await callTool("list_notes", {});
+      expect(result.notes).toBeDefined();
+      expect(result.total_count).toBeGreaterThan(0);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      for (const note of result.notes) {
+        expect(note.content).toBeUndefined();
+        expect(note.id).toBeDefined();
+        expect(note.title).toBeDefined();
+      }
+    });
+
+    it("filters by scope", async () => {
+      await callTool("create_note", {
+        title: "Work-scoped list note",
+        content: "work content",
+        scope: "work",
+      });
+      await callTool("create_note", {
+        title: "Personal-scoped list note",
+        content: "personal content",
+        scope: "personal",
+      });
+
+      const result = await callTool("list_notes", { scope: "work" });
+      for (const note of result.notes) {
+        expect(note.scope).toBe("work");
+      }
+    });
+
+    it("filters by domain", async () => {
+      await callTool("create_note", {
+        title: "Architecture note",
+        content: "arch content",
+        scope: "work",
+        domain: "architecture-unique-xyz",
+      });
+
+      const result = await callTool("list_notes", {
+        domain: "architecture-unique-xyz",
+      });
+      expect(result.total_count).toBeGreaterThanOrEqual(1);
+      for (const note of result.notes) {
+        expect(note.domain).toBe("architecture-unique-xyz");
+      }
+    });
+
+    it("filters by tags with ANY-match", async () => {
+      await callTool("create_note", {
+        title: "Tagged note",
+        content: "body",
+        scope: "personal",
+        tags: ["unique-note-tag-abc"],
+      });
+
+      const result = await callTool("list_notes", {
+        tags: ["unique-note-tag-abc", "nonexistent"],
+      });
+      expect(result.total_count).toBeGreaterThanOrEqual(1);
+    });
+
+    it("respects limit and offset", async () => {
+      const page1 = await callTool("list_notes", { limit: 2, offset: 0 });
+      const page2 = await callTool("list_notes", { limit: 2, offset: 2 });
+      expect(page1.notes.length).toBeLessThanOrEqual(2);
+      expect(page2.notes.length).toBeLessThanOrEqual(2);
+      if (page1.notes.length > 0 && page2.notes.length > 0) {
+        expect(page1.notes[0].id).not.toBe(page2.notes[0].id);
+      }
+    });
+  });
+
+  describe("search_notes", () => {
+    it("finds notes by keyword in title or content", async () => {
+      await callTool("create_note", {
+        title: "Observability patterns",
+        content: "Structured logging with correlation IDs.",
+        scope: "work",
+      });
+
+      const result = await callTool("search_notes", {
+        query: "structured logging",
+      });
+      expect(result.notes.length).toBeGreaterThanOrEqual(1);
+      const found = result.notes.some((n: any) =>
+        n.title.includes("Observability") || n.content.includes("logging")
+      );
+      expect(found).toBe(true);
+    });
+
+    it("includes full content in search results (unlike list)", async () => {
+      await callTool("create_note", {
+        title: "Search content marker xyzqrs",
+        content: "Body content for search test.",
+        scope: "personal",
+      });
+
+      const result = await callTool("search_notes", { query: "xyzqrs" });
+      expect(result.notes.length).toBeGreaterThanOrEqual(1);
+      expect(result.notes[0].content).toBeDefined();
+    });
+
+    it("filters by scope", async () => {
+      await callTool("create_note", {
+        title: "Scope search marker aabbcc",
+        content: "content",
+        scope: "work",
+      });
+
+      const personal = await callTool("search_notes", {
+        query: "aabbcc",
+        scope: "personal",
+      });
+      expect(personal.notes.length).toBe(0);
+
+      const work = await callTool("search_notes", {
+        query: "aabbcc",
+        scope: "work",
+      });
+      expect(work.notes.length).toBe(1);
+    });
+
+    it("returns validation error for empty query", async () => {
+      const result = await callTool("search_notes", { query: "" });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("update_note", () => {
+    it("updates field-level properties", async () => {
+      const created = await callTool("create_note", {
+        title: "Original title",
+        content: "Original content",
+        scope: "personal",
+      });
+
+      const result = await callTool("update_note", {
+        id: created.id,
+        title: "Updated title",
+        content: "Updated content",
+        domain: "new-domain",
+        tags: ["updated"],
+      });
+      expect(result.title).toBe("Updated title");
+      expect(result.content).toBe("Updated content");
+      expect(result.domain).toBe("new-domain");
+      expect(result.tags).toEqual(["updated"]);
+    });
+
+    it("returns NOT_FOUND for non-existent note", async () => {
+      const result = await callTool("update_note", {
+        id: "00000000-0000-0000-0000-000000000000",
+        title: "anything",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+
+    it("returns VALIDATION_ERROR when no updates provided", async () => {
+      const created = await callTool("create_note", {
+        title: "Empty-update test",
+        content: "content",
+        scope: "personal",
+      });
+      const result = await callTool("update_note", { id: created.id });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("delete_note", () => {
+    it("deletes an existing note and returns {deleted: true}", async () => {
+      const created = await callTool("create_note", {
+        title: "To be deleted",
+        content: "Goodbye",
+        scope: "personal",
+      });
+
+      const result = await callTool("delete_note", { id: created.id });
+      expect(result.deleted).toBe(true);
+      expect(result.id).toBe(created.id);
+
+      const fetched = await callTool("get_note", { id: created.id });
+      expect(fetched.error).toBe(true);
+      expect(fetched.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND for non-existent note", async () => {
+      const result = await callTool("delete_note", {
+        id: "00000000-0000-0000-0000-000000000000",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("cross-tool isolation", () => {
+    it("notes do NOT appear in list_tasks", async () => {
+      const note = await callTool("create_note", {
+        title: "Isolation-test note marker fffeee",
+        content: "Should not show up in tasks",
+        scope: "personal",
+      });
+
+      const list = await callTool("list_tasks", { status: null });
+      const found = list.tasks?.some((t: any) => t.id === note.id);
+      expect(found).toBeFalsy();
+    });
+
+    it("notes do NOT appear in search_tasks", async () => {
+      await callTool("create_note", {
+        title: "SearchIsolationMarkerGgghhh",
+        content: "Isolation body",
+        scope: "personal",
+      });
+
+      const result = await callTool("search_tasks", {
+        query: "SearchIsolationMarkerGgghhh",
+      });
+      expect(result.tasks.length).toBe(0);
+    });
+  });
+});

--- a/src/db/migrations/005_notes.sql
+++ b/src/db/migrations/005_notes.sql
@@ -1,0 +1,31 @@
+-- Knowledge layer: permanent, searchable notes.
+-- Distinct from tasks (no lifecycle) and handoffs (not ephemeral).
+
+CREATE TABLE IF NOT EXISTS notes (
+    id                UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    title             TEXT          NOT NULL,
+    content           TEXT          NOT NULL,
+    domain            TEXT,
+    tags              TEXT[]        DEFAULT '{}',
+    scope             TEXT          NOT NULL CHECK (scope IN ('work', 'personal', 'shared')),
+    source_url        TEXT,
+    related_task_ids  UUID[]        DEFAULT '{}',
+    created_at        TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_scope ON notes (scope);
+CREATE INDEX IF NOT EXISTS idx_notes_tags ON notes USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_notes_domain ON notes (domain);
+CREATE INDEX IF NOT EXISTS idx_notes_created ON notes (created_at DESC);
+
+-- Full-text search on title + content
+CREATE INDEX IF NOT EXISTS idx_notes_fts ON notes
+    USING GIN (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')));
+
+-- Reuse update_updated_at() trigger function from 001_tasks.sql
+DROP TRIGGER IF EXISTS notes_updated_at ON notes;
+CREATE TRIGGER notes_updated_at
+    BEFORE UPDATE ON notes
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();

--- a/src/embeddings/indexer.ts
+++ b/src/embeddings/indexer.ts
@@ -78,6 +78,30 @@ export async function indexTask(
   await indexContent("task", id, text, { scope, tags, status });
 }
 
+/** Index a single note. */
+export async function indexNote(
+  id: string,
+  note: {
+    title: string;
+    content: string;
+    domain?: string | null;
+    tags?: string[] | null;
+    scope?: string;
+    created_at?: string;
+  }
+): Promise<void> {
+  const tagLine = note.tags?.length ? note.tags.join(", ") : "";
+  const parts = [note.title, note.content, note.domain ?? "", tagLine];
+  const text = parts.filter((p) => p && p.trim()).join("\n");
+  await indexContent("note", id, text, {
+    note_id: id,
+    domain: note.domain ?? null,
+    tags: note.tags ?? [],
+    scope: note.scope ?? null,
+    created_at: note.created_at ?? null,
+  });
+}
+
 /** Bulk index all existing handoff files. For initial backfill. */
 export async function indexAllHandoffs(): Promise<{
   indexed: number;
@@ -148,6 +172,41 @@ export async function indexAllTasks(): Promise<number> {
     } catch (err) {
       console.error(
         `[indexer] Failed to index task ${row.id}:`,
+        (err as Error).message
+      );
+    }
+  }
+
+  return indexed;
+}
+
+/** Bulk index all notes from the notes table. */
+export async function indexAllNotes(): Promise<number> {
+  const result = await query<{
+    id: string;
+    title: string;
+    content: string;
+    domain: string | null;
+    tags: string[];
+    scope: string;
+    created_at: string;
+  }>("SELECT id, title, content, domain, tags, scope, created_at FROM notes");
+
+  let indexed = 0;
+  for (const row of result.rows) {
+    try {
+      await indexNote(row.id, {
+        title: row.title,
+        content: row.content,
+        domain: row.domain,
+        tags: row.tags,
+        scope: row.scope,
+        created_at: row.created_at,
+      });
+      indexed++;
+    } catch (err) {
+      console.error(
+        `[indexer] Failed to index note ${row.id}:`,
         (err as Error).message
       );
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { config } from "./config.js";
 import { registerHandoffTools } from "./tools/handoff.js";
 import { registerTaskTools } from "./tools/tasks.js";
+import { registerNoteTools } from "./tools/notes.js";
 import { registerSearchTools } from "./tools/search.js";
 import { ensureDataDir } from "./storage/json-store.js";
 import { runMigrations } from "./db/migrate.js";
@@ -80,6 +81,7 @@ function createMcpServer(): McpServer {
   });
   registerHandoffTools(server);
   registerTaskTools(server);
+  registerNoteTools(server);
   registerSearchTools(server);
   return server;
 }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,0 +1,433 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { query } from "../db/client.js";
+import { indexNote } from "../embeddings/indexer.js";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface NoteRow {
+  id: string;
+  title: string;
+  content: string;
+  domain: string | null;
+  tags: string[];
+  scope: string;
+  source_url: string | null;
+  related_task_ids: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+function formatNote(row: NoteRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    domain: row.domain,
+    tags: row.tags || [],
+    scope: row.scope,
+    source_url: row.source_url,
+    related_task_ids: row.related_task_ids || [],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function formatNoteListItem(row: NoteRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    domain: row.domain,
+    scope: row.scope,
+    tags: row.tags || [],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function jsonResponse(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
+
+function errorResponse(message: string, code: string) {
+  return jsonResponse({ error: true, message, code });
+}
+
+// ── Zod Schemas ──────────────────────────────────────────────────
+
+const scopeEnum = z.enum(["work", "personal", "shared"]);
+const listOrderByEnum = z.enum(["created_at", "updated_at"]);
+const orderDirEnum = z.enum(["asc", "desc"]);
+
+// ── Tool Descriptions ────────────────────────────────────────────
+
+const CREATE_NOTE_DESC = `Create a permanent knowledge entry. Use for decisions made, approaches tried, constraints discovered, patterns identified, article takeaways, and connections between ideas — anything that should survive across sessions and never be compacted away.
+
+Knowledge is distinct from the other two primitives:
+- Tasks are action items with a lifecycle (open → completed). "Research X" is a task.
+- Handoffs are ephemeral session state that gets compacted over time.
+- Notes are permanent interpretation — the reasoning, the decision, the insight. "After researching X, we decided Y because Z" is knowledge.
+
+Use the 'domain' field to categorize (e.g., 'architecture', 'security', 'career', 'health'). Tags are free-form and compose with domain. The 'scope' field separates work/personal/shared knowledge. Provide 'source_url' when capturing takeaways from external material. Set 'related_task_ids' to link a note back to the tasks that produced it.
+
+Content can be long — notes do not compact.`;
+
+const GET_NOTE_DESC = `Retrieve a single note by its UUID. Returns the full note object including content.`;
+
+const LIST_NOTES_DESC = `List knowledge entries with optional filters and pagination. Returns metadata only (id, title, domain, scope, tags, timestamps) — NOT the full content. Call get_note for the body.
+
+Defaults to newest-first by created_at. Filter by scope, domain, or tags (ANY-match). Use search_notes or search_context when you want relevance ranking instead of filtered browsing.`;
+
+const SEARCH_NOTES_DESC = `Full-text search across note titles and content. Uses PostgreSQL FTS with English stemming, ranked by relevance. Returns matching notes WITH full content (unlike list_notes).
+
+Filter by scope and domain. For cross-type semantic search that finds relevant notes alongside handoffs and tasks, use search_context with content_types: ["note"] instead — this tool only searches within the notes table.`;
+
+const UPDATE_NOTE_DESC = `Update fields on an existing note. All fields are optional — only provided fields are modified. Tags and related_task_ids are full-replacement (provide complete arrays). Re-embeds on content change.`;
+
+const DELETE_NOTE_DESC = `Permanently delete a note by UUID. Also removes its entry from the embeddings index. Knowledge entries are intended to be permanent — use this only for corrections or cleanup. Deletion cannot be undone.`;
+
+// ── Tool Registration ────────────────────────────────────────────
+
+export function registerNoteTools(mcpServer: McpServer): void {
+  // ── create_note ──────────────────────────────────────────────
+  mcpServer.tool(
+    "create_note",
+    CREATE_NOTE_DESC,
+    {
+      title: z.string().describe("Short descriptive title for the knowledge entry"),
+      content: z.string().describe("The knowledge content — decisions, insights, patterns, takeaways. Can be long."),
+      scope: scopeEnum.describe("'work', 'personal', or 'shared'"),
+      domain: z.string().optional().describe("Knowledge domain for categorization (e.g., 'architecture', 'security', 'career', 'health')"),
+      tags: z.array(z.string()).optional().describe("Free-form tags for categorization"),
+      source_url: z.string().optional().describe("URL of the source material, if applicable"),
+      related_task_ids: z.array(z.string()).optional().describe("UUIDs of related tasks, if applicable"),
+    },
+    async (args) => {
+      if (!args.title?.trim()) {
+        return errorResponse("title is required", "VALIDATION_ERROR");
+      }
+      if (!args.content?.trim()) {
+        return errorResponse("content is required", "VALIDATION_ERROR");
+      }
+
+      try {
+        const result = await query<NoteRow>(
+          `INSERT INTO notes (title, content, domain, tags, scope, source_url, related_task_ids)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           RETURNING *`,
+          [
+            args.title,
+            args.content,
+            args.domain ?? null,
+            args.tags ?? [],
+            args.scope,
+            args.source_url ?? null,
+            args.related_task_ids ?? [],
+          ]
+        );
+        const row = result.rows[0];
+        indexNote(row.id, {
+          title: row.title,
+          content: row.content,
+          domain: row.domain,
+          tags: row.tags,
+          scope: row.scope,
+          created_at: row.created_at,
+        }).catch((err) =>
+          console.warn("[create_note] Background indexing failed:", err.message)
+        );
+        return jsonResponse({
+          id: row.id,
+          title: row.title,
+          created_at: row.created_at,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── get_note ─────────────────────────────────────────────────
+  mcpServer.tool(
+    "get_note",
+    GET_NOTE_DESC,
+    {
+      id: z.string().describe("UUID of the note to retrieve"),
+    },
+    async (args) => {
+      try {
+        const result = await query<NoteRow>(
+          "SELECT * FROM notes WHERE id = $1",
+          [args.id]
+        );
+        if (result.rows.length === 0) {
+          return errorResponse(`Note not found: ${args.id}`, "NOT_FOUND");
+        }
+        return jsonResponse(formatNote(result.rows[0]));
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── list_notes ───────────────────────────────────────────────
+  mcpServer.tool(
+    "list_notes",
+    LIST_NOTES_DESC,
+    {
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 20)"),
+      offset: z.number().min(0).optional().describe("Offset for pagination (default 0)"),
+      scope: scopeEnum.nullable().optional().describe("Filter by scope (null/omitted = all scopes)"),
+      domain: z.string().optional().describe("Filter by domain"),
+      tags: z.array(z.string()).optional().describe("Filter by tags (ANY match)"),
+      order_by: listOrderByEnum.optional().describe("Sort field (default: 'created_at')"),
+      order_dir: orderDirEnum.optional().describe("Sort direction (default: 'desc')"),
+    },
+    async (args) => {
+      try {
+        const conditions: string[] = [];
+        const params: unknown[] = [];
+        let paramIdx = 1;
+
+        if (args.scope) {
+          conditions.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+
+        if (args.domain) {
+          conditions.push(`domain = $${paramIdx++}`);
+          params.push(args.domain);
+        }
+
+        if (args.tags && args.tags.length > 0) {
+          conditions.push(`tags && $${paramIdx++}`);
+          params.push(args.tags);
+        }
+
+        const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+        const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+        const offset = Math.max(args.offset ?? 0, 0);
+        const orderBy = args.order_by ?? "created_at";
+        const orderDir = (args.order_dir ?? "desc").toUpperCase();
+        const orderClause = `ORDER BY ${orderBy} ${orderDir} NULLS LAST`;
+
+        const countResult = await query<{ count: string }>(
+          `SELECT COUNT(*) as count FROM notes ${where}`,
+          params
+        );
+        const totalCount = parseInt(countResult.rows[0].count, 10);
+
+        const dataResult = await query<NoteRow>(
+          `SELECT * FROM notes ${where} ${orderClause} LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+          [...params, limit, offset]
+        );
+
+        return jsonResponse({
+          notes: dataResult.rows.map(formatNoteListItem),
+          total_count: totalCount,
+          limit,
+          offset,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── search_notes ─────────────────────────────────────────────
+  mcpServer.tool(
+    "search_notes",
+    SEARCH_NOTES_DESC,
+    {
+      query: z.string().describe("Full-text search query"),
+      scope: scopeEnum.nullable().optional().describe("Filter by scope"),
+      domain: z.string().optional().describe("Filter by domain"),
+      limit: z.number().min(1).max(50).optional().describe("Max results (1-50, default 10)"),
+    },
+    async (args) => {
+      if (!args.query?.trim()) {
+        return errorResponse("query is required", "VALIDATION_ERROR");
+      }
+
+      try {
+        const conditions: string[] = [
+          `to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')) @@ plainto_tsquery('english', $1)`,
+        ];
+        const params: unknown[] = [args.query];
+        let paramIdx = 2;
+
+        if (args.scope) {
+          conditions.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+
+        if (args.domain) {
+          conditions.push(`domain = $${paramIdx++}`);
+          params.push(args.domain);
+        }
+
+        const limit = Math.min(Math.max(args.limit ?? 10, 1), 50);
+        const where = conditions.join(" AND ");
+
+        const countResult = await query<{ count: string }>(
+          `SELECT COUNT(*) as count FROM notes WHERE ${where}`,
+          params
+        );
+        const totalCount = parseInt(countResult.rows[0].count, 10);
+
+        const dataResult = await query<NoteRow & { rank: number }>(
+          `SELECT *, ts_rank(
+            to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')),
+            plainto_tsquery('english', $1)
+          ) AS rank
+          FROM notes WHERE ${where}
+          ORDER BY rank DESC
+          LIMIT $${paramIdx}`,
+          [...params, limit]
+        );
+
+        return jsonResponse({
+          notes: dataResult.rows.map((row) => ({
+            ...formatNote(row),
+            rank: row.rank,
+          })),
+          total_count: totalCount,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── update_note ──────────────────────────────────────────────
+  mcpServer.tool(
+    "update_note",
+    UPDATE_NOTE_DESC,
+    {
+      id: z.string().describe("UUID of the note to update"),
+      title: z.string().optional().describe("New title"),
+      content: z.string().optional().describe("New content"),
+      domain: z.string().nullable().optional().describe("New domain, or null to clear"),
+      tags: z.array(z.string()).optional().describe("New tags (full replacement)"),
+      scope: scopeEnum.optional().describe("New scope"),
+      source_url: z.string().nullable().optional().describe("New source URL, or null to clear"),
+      related_task_ids: z.array(z.string()).optional().describe("New related task IDs (full replacement)"),
+    },
+    async (args) => {
+      try {
+        const existing = await query<NoteRow>(
+          "SELECT * FROM notes WHERE id = $1",
+          [args.id]
+        );
+        if (existing.rows.length === 0) {
+          return errorResponse(`Note not found: ${args.id}`, "NOT_FOUND");
+        }
+
+        const sets: string[] = [];
+        const params: unknown[] = [];
+        let paramIdx = 1;
+
+        if (args.title !== undefined) {
+          sets.push(`title = $${paramIdx++}`);
+          params.push(args.title);
+        }
+        if (args.content !== undefined) {
+          sets.push(`content = $${paramIdx++}`);
+          params.push(args.content);
+        }
+        if (args.domain !== undefined) {
+          sets.push(`domain = $${paramIdx++}`);
+          params.push(args.domain);
+        }
+        if (args.tags !== undefined) {
+          sets.push(`tags = $${paramIdx++}`);
+          params.push(args.tags);
+        }
+        if (args.scope !== undefined) {
+          sets.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+        if (args.source_url !== undefined) {
+          sets.push(`source_url = $${paramIdx++}`);
+          params.push(args.source_url);
+        }
+        if (args.related_task_ids !== undefined) {
+          sets.push(`related_task_ids = $${paramIdx++}`);
+          params.push(args.related_task_ids);
+        }
+
+        if (sets.length === 0) {
+          return errorResponse("No updates provided", "VALIDATION_ERROR");
+        }
+
+        const result = await query<NoteRow>(
+          `UPDATE notes SET ${sets.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
+          [...params, args.id]
+        );
+        const row = result.rows[0];
+
+        const contentChanged =
+          args.title !== undefined ||
+          args.content !== undefined ||
+          args.domain !== undefined ||
+          args.tags !== undefined;
+        if (contentChanged) {
+          indexNote(row.id, {
+            title: row.title,
+            content: row.content,
+            domain: row.domain,
+            tags: row.tags,
+            scope: row.scope,
+            created_at: row.created_at,
+          }).catch((err) =>
+            console.warn("[update_note] Background indexing failed:", err.message)
+          );
+        }
+
+        return jsonResponse(formatNote(row));
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── delete_note ──────────────────────────────────────────────
+  mcpServer.tool(
+    "delete_note",
+    DELETE_NOTE_DESC,
+    {
+      id: z.string().describe("UUID of the note to delete"),
+    },
+    async (args) => {
+      try {
+        const result = await query<{ id: string }>(
+          "DELETE FROM notes WHERE id = $1 RETURNING id",
+          [args.id]
+        );
+        if (result.rows.length === 0) {
+          return errorResponse(`Note not found: ${args.id}`, "NOT_FOUND");
+        }
+
+        // Remove from embeddings index — fire-and-forget, but awaited briefly
+        // so typical callers see a clean state. Errors are logged, not thrown.
+        try {
+          await query(
+            "DELETE FROM embeddings WHERE content_type = 'note' AND content_id = $1",
+            [args.id]
+          );
+        } catch (err) {
+          console.warn(
+            "[delete_note] Failed to remove embedding:",
+            (err as Error).message
+          );
+        }
+
+        return jsonResponse({ deleted: true, id: args.id });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { query } from "../db/client.js";
 import { generateEmbedding, isEmbeddingAvailable } from "../embeddings/client.js";
-import { indexAllHandoffs, indexAllTasks } from "../embeddings/indexer.js";
+import { indexAllHandoffs, indexAllTasks, indexAllNotes } from "../embeddings/indexer.js";
 import { lookupEntities, computeEnvelope, emptyEnvelope, generateBoundaryNotice } from "./entities.js";
 
 /**
@@ -87,14 +87,14 @@ Response Format:
 - Reasoning-capable models (Claude Opus, o1, Gemini with thinking): Use structured reflection before synthesizing results. Evaluate whether retrieved evidence actually supports the user's question. Note gaps explicitly when results are thin or off-topic.
 - Standard models (Claude Sonnet/Haiku, GPT-4.x, Gemini Flash): Respond directly using available results. Flag when results seem insufficient and suggest query reformulation.`;
 
-const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs and tasks. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
+const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs, tasks, and notes. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
 
 WARNING: Can take several minutes for large datasets (1000+ handoffs). Re-embeds all content, not just changed items. Inform the user of expected duration before running.
 
 Parameters:
-  - content_types (optional): Which to reindex. Default: all. Options: 'handoff', 'task'
+  - content_types (optional): Which to reindex. Default: all. Options: 'handoff', 'task', 'note'
 
-Returns: {handoffs: {indexed, skipped, errors}, tasks: {indexed}}`;
+Returns: {handoffs: {indexed, skipped, errors}, tasks: {indexed}, notes: {indexed}}`;
 
 export function registerSearchTools(mcpServer: McpServer): void {
   // \u2500\u2500 search_context \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -104,7 +104,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
     {
       query: z.string().describe("Natural language search query"),
       content_types: z
-        .array(z.enum(["handoff", "task", "document", "transcript"]))
+        .array(z.enum(["handoff", "task", "note", "document", "transcript"]))
         .optional()
         .describe("Filter by content type. Default: search all."),
       limit: z
@@ -295,7 +295,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
     REINDEX_DESCRIPTION,
     {
       content_types: z
-        .array(z.enum(["handoff", "task"]))
+        .array(z.enum(["handoff", "task", "note"]))
         .optional()
         .describe("Which types to reindex. Default: all."),
     },
@@ -314,7 +314,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
         };
       }
 
-      const types = args.content_types ?? ["handoff", "task"];
+      const types = args.content_types ?? ["handoff", "task", "note"];
       const results: Record<string, unknown> = {};
 
       if (types.includes("handoff")) {
@@ -324,6 +324,11 @@ export function registerSearchTools(mcpServer: McpServer): void {
       if (types.includes("task")) {
         const count = await indexAllTasks();
         results.tasks = { indexed: count };
+      }
+
+      if (types.includes("note")) {
+        const count = await indexAllNotes();
+        results.notes = { indexed: count };
       }
 
       return {


### PR DESCRIPTION
## Summary

Introduces the **Knowledge layer** (third content primitive) alongside Handoffs (ephemeral) and Tasks (lifecycle). Notes are permanent, searchable, and never compact — the home for decisions made, approaches tried, constraints discovered, patterns identified, and article takeaways.

- New `notes` table (migration `005_notes.sql`) with scope CHECK, FTS + GIN indexes, and `updated_at` trigger
- Six MCP tools in `src/tools/notes.ts`: `create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note` — each with a cold-start briefing description
- `indexNote` + `indexAllNotes` in the embeddings indexer; fire-and-forget embedding on create/update; removal on delete
- `'note'` added to `content_types` in `search_context` and `reindex`; unified semantic search spans handoffs + tasks + notes
- Integration tests cover CRUD, FTS search, filters, pagination, and cross-tool isolation (skip gracefully when Postgres is unavailable)
- `ROADMAP.md` — Knowledge layer pulled forward from v0.7 into v0.6

## Design notes

- **Separate tools, not polymorphic.** Six discrete tools instead of `store_context(type: 'knowledge')` — reliability over token savings, especially critical for Haiku-tier routing.
- **Permanent lifecycle.** No status field, no completion, no archival. Distinct from tasks, which have a lifecycle, and handoffs, which compact.
- **Unified semantic search.** Notes ride the same pgvector + FTS index as handoffs and tasks, so `search_context` returns them by default.
- **Delete is permanent.** Tool description warns that deletion cannot be undone; included for corrections/cleanup only.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full test suite green locally (92 passed; 52 Postgres-backed skipped without DB)
- [x] CI runs notes.test.ts against pgvector/pgvector:pg16 (requires Postgres service)
- [x] Manual smoke: `create_note` → `search_context(content_types: ["note"])` returns the note
- [x] Manual smoke: `reindex` with default args includes the notes table

🤖 Generated with [Claude Code](https://claude.com/claude-code)