### PR TITLE
feat: handoff navigation tools and dynamic task summary

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -708,6 +708,233 @@ describe("MCP Tools", () => {
 });
 
 // ────────────────────────────────────────────────
+// list_handoffs / get_handoff tests
+// ────────────────────────────────────────────────
+
+describe("Handoff Navigation", () => {
+  describe("list_handoffs", () => {
+    it("appears in tools/list", async () => {
+      const res = await mcpPost(jsonrpc("tools/list"));
+      const data = (await parseSseResponse(res)) as any;
+      const toolNames: string[] = data.result.tools.map((t: any) => t.name);
+      expect(toolNames).toContain("list_handoffs");
+      expect(toolNames).toContain("get_handoff");
+    });
+
+    it("returns metadata array (not full content) sorted newest first", async () => {
+      // Store two handoffs with distinct content
+      await storeAndVerify({
+        tone_notes: "older",
+        active_context: { session_meta: { label: "list-test-older" } },
+        tasks: { open: ["a"], completed: [], blocked: [] },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      await storeAndVerify({
+        tone_notes: "newer",
+        active_context: { session_meta: { label: "list-test-newer" } },
+      });
+
+      const res = await mcpPost(
+        jsonrpc("tools/call", { name: "list_handoffs", arguments: { limit: 5 } })
+      );
+      expect(res.status).toBe(200);
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+
+      expect(Array.isArray(result.handoffs)).toBe(true);
+      expect(result.handoffs.length).toBeGreaterThan(0);
+      expect(typeof result.total_count).toBe("number");
+      expect(result.limit).toBe(5);
+      expect(result.offset).toBe(0);
+
+      // Metadata-only shape — no tone_notes or operational_state
+      const entry = result.handoffs[0];
+      expect(entry).toHaveProperty("filename");
+      expect(entry).toHaveProperty("stored_at");
+      expect(entry).toHaveProperty("session_label");
+      expect(entry).toHaveProperty("size_bytes");
+      expect(entry).toHaveProperty("has_tasks");
+      expect(entry).toHaveProperty("schema_version");
+      expect(entry).not.toHaveProperty("tone_notes");
+      expect(entry).not.toHaveProperty("operational_state");
+
+      // Newest-first ordering — find both known labels and confirm newer precedes older
+      const labels = result.handoffs.map((h: any) => h.session_label);
+      const newerIdx = labels.indexOf("list-test-newer");
+      const olderIdx = labels.indexOf("list-test-older");
+      expect(newerIdx).toBeGreaterThanOrEqual(0);
+      expect(olderIdx).toBeGreaterThanOrEqual(0);
+      expect(newerIdx).toBeLessThan(olderIdx);
+    });
+
+    it("extracts session_label and has_tasks correctly", async () => {
+      await storeAndVerify({
+        active_context: { session_meta: { label: "meta-label-test" } },
+        tasks: { open: ["x"], completed: [], blocked: [] },
+      });
+
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "list_handoffs",
+          arguments: { limit: 10 },
+        })
+      );
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+      const match = result.handoffs.find(
+        (h: any) => h.session_label === "meta-label-test"
+      );
+      expect(match).toBeDefined();
+      expect(match.has_tasks).toBe(true);
+      expect(match.size_bytes).toBeGreaterThan(0);
+    });
+
+    it("applies pagination with limit and offset", async () => {
+      const resPage1 = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "list_handoffs",
+          arguments: { limit: 1, offset: 0 },
+        })
+      );
+      const dataPage1 = (await parseSseResponse(resPage1)) as any;
+      const page1 = JSON.parse(dataPage1.result.content[0].text);
+      expect(page1.handoffs.length).toBe(1);
+      expect(page1.limit).toBe(1);
+      expect(page1.offset).toBe(0);
+
+      const resPage2 = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "list_handoffs",
+          arguments: { limit: 1, offset: 1 },
+        })
+      );
+      const dataPage2 = (await parseSseResponse(resPage2)) as any;
+      const page2 = JSON.parse(dataPage2.result.content[0].text);
+      expect(page2.offset).toBe(1);
+
+      if (page1.total_count > 1) {
+        expect(page1.handoffs[0].filename).not.toBe(page2.handoffs[0].filename);
+      }
+    });
+
+    it("filters by after date", async () => {
+      // Everything stored is "after the epoch" — verify filter excludes handoffs before a future date
+      const future = new Date(Date.now() + 1000 * 60 * 60).toISOString();
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "list_handoffs",
+          arguments: { after: future },
+        })
+      );
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+      expect(result.handoffs.length).toBe(0);
+      expect(result.total_count).toBe(0);
+    });
+
+    it("filters by before date", async () => {
+      const past = new Date(0).toISOString();
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "list_handoffs",
+          arguments: { before: past },
+        })
+      );
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+      expect(result.handoffs.length).toBe(0);
+      expect(result.total_count).toBe(0);
+    });
+  });
+
+  describe("get_handoff", () => {
+    it("retrieves a specific handoff by filename", async () => {
+      const stored = await storeAndVerify({
+        tone_notes: "get_handoff target",
+        active_context: { session_meta: { label: "get-handoff-test" } },
+        tasks: { open: ["foo"], completed: [], blocked: [] },
+      });
+
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "get_handoff",
+          arguments: { filename: stored.filename },
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+
+      expect(result.error).toBeUndefined();
+      expect(result.tone_notes).toBe("get_handoff target");
+      expect(result.active_context.session_meta.label).toBe("get-handoff-test");
+      expect(result.applied_scope).toBe("full");
+      expect(result.schema_version).toBe("1.1");
+      expect(result.task_summary).toBeDefined();
+      expect(typeof result.elapsed_seconds).toBe("number");
+    });
+
+    it("applies scope filtering", async () => {
+      const stored = await storeAndVerify({
+        operational_state: { sleep_hours: "7", mood: "ok" },
+        tone_notes: "scope filter",
+        tasks: { open: ["t"], completed: [], blocked: [] },
+      });
+
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "get_handoff",
+          arguments: { filename: stored.filename, scope: "work" },
+        })
+      );
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+      expect(result.applied_scope).toBe("work");
+      expect(result.filtered_fields).toBeDefined();
+      // sleep_hours is personal — should be filtered out under 'work' scope
+      expect(result.filtered_fields).toContain("operational_state.sleep_hours");
+    });
+
+    it("returns NOT_FOUND for unknown filename", async () => {
+      const res = await mcpPost(
+        jsonrpc("tools/call", {
+          name: "get_handoff",
+          arguments: {
+            filename: "2099-01-01T00-00-00-000Z-deadbeef.json",
+          },
+        })
+      );
+      const data = (await parseSseResponse(res)) as any;
+      const result = JSON.parse(data.result.content[0].text);
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+
+    it("rejects path traversal attempts", async () => {
+      const attempts = [
+        "../../../etc/passwd",
+        "../secret.json",
+        "sub/dir.json",
+        "..\\windows\\file.json",
+        "not-a-valid-handoff.json",
+      ];
+      for (const filename of attempts) {
+        const res = await mcpPost(
+          jsonrpc("tools/call", {
+            name: "get_handoff",
+            arguments: { filename },
+          })
+        );
+        const data = (await parseSseResponse(res)) as any;
+        const result = JSON.parse(data.result.content[0].text);
+        expect(result.error).toBe(true);
+        expect(result.code).toBe("NOT_FOUND");
+      }
+    });
+  });
+});
+
+// ────────────────────────────────────────────────
 // Embedding unavailability tests
 // ────────────────────────────────────────────────
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -605,7 +605,12 @@ describe("MCP Tools", () => {
       expect(retrieved.same_calendar_day).toBe(true);
     });
 
-    it("task_summary counts match actual array lengths", async () => {
+    it("task_summary exposes numeric counts (shape is stable across fallback and dynamic sources)", async () => {
+      // When Postgres is unavailable, task_summary is the fallback shape derived from handoff
+      // arrays: {open_count, blocked_count, completed_count}. When Postgres is available, counts
+      // come from the tasks table and the shape is enriched with item arrays. This test asserts
+      // the minimum contract both paths share. Exact-count fallback behavior is covered by the
+      // patch_handoff "task_summary counts in response" test, which stays on handoff arrays.
       await storeAndVerify({
         tasks: { open: ["x", "y"], completed: ["z"], blocked: [] },
       });
@@ -615,11 +620,9 @@ describe("MCP Tools", () => {
       );
       const getData = (await parseSseResponse(getRes)) as any;
       const retrieved = JSON.parse(getData.result.content[0].text);
-      expect(retrieved.task_summary).toEqual({
-        open_count: 2,
-        blocked_count: 0,
-        completed_count: 1,
-      });
+      expect(typeof retrieved.task_summary.open_count).toBe("number");
+      expect(typeof retrieved.task_summary.blocked_count).toBe("number");
+      expect(typeof retrieved.task_summary.completed_count).toBe("number");
     });
 
     it("applied_scope matches requested scope", async () => {

--- a/src/__tests__/tasks.test.ts
+++ b/src/__tests__/tasks.test.ts
@@ -550,4 +550,116 @@ describe.skipIf(!pgAvailable)("Task Tools", () => {
       expect(result.code).toBe("VALIDATION_ERROR");
     });
   });
+
+  describe("dynamic task_summary in get_latest_handoff", () => {
+    it("returns enriched task_summary from Postgres (counts + item arrays)", async () => {
+      // Seed a known mix of tasks
+      const critical = await callTool("create_task", {
+        title: "Critical task summary test",
+        scope: "work",
+        priority: "critical",
+        due_date: "2099-01-15",
+      });
+      const blocked = await callTool("create_task", {
+        title: "Blocked task summary test",
+        scope: "work",
+        blocked_reason: "Waiting for upstream",
+      });
+      const toComplete = await callTool("create_task", {
+        title: "Recently completed summary test",
+        scope: "work",
+      });
+      await callTool("update_task", { id: toComplete.id, action: "complete" });
+
+      // Due this week — use a date 3 days out
+      const threeDaysOut = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
+      await callTool("create_task", {
+        title: "Due this week summary test",
+        scope: "work",
+        due_date: threeDaysOut,
+      });
+
+      // Store a handoff so get_latest_handoff has something to return
+      await callTool("store_handoff", {
+        tone_notes: "dynamic summary test",
+      });
+
+      const result = await callTool("get_latest_handoff", {});
+      const ts = result.task_summary;
+
+      // Enriched shape present
+      expect(Array.isArray(ts.critical_items)).toBe(true);
+      expect(Array.isArray(ts.due_this_week)).toBe(true);
+      expect(Array.isArray(ts.recently_completed)).toBe(true);
+      expect(Array.isArray(ts.blocked_items)).toBe(true);
+      expect(typeof ts.open_count).toBe("number");
+      expect(typeof ts.blocked_count).toBe("number");
+      expect(typeof ts.completed_count).toBe("number");
+
+      // Counts reflect Postgres, not handoff arrays (which were empty)
+      expect(ts.open_count).toBeGreaterThan(0);
+      expect(ts.completed_count).toBeGreaterThan(0);
+      expect(ts.blocked_count).toBeGreaterThan(0);
+
+      // Critical item surfaced
+      expect(ts.critical_items.some((i: any) => i.id === critical.id)).toBe(true);
+      // Blocked item surfaced with reason
+      const blockedItem = ts.blocked_items.find((i: any) => i.id === blocked.id);
+      expect(blockedItem).toBeDefined();
+      expect(blockedItem.blocked_reason).toBe("Waiting for upstream");
+      // Recently completed surfaced
+      expect(
+        ts.recently_completed.some((i: any) => i.id === toComplete.id)
+      ).toBe(true);
+      // Due this week surfaced
+      expect(
+        ts.due_this_week.some((i: any) => i.title === "Due this week summary test")
+      ).toBe(true);
+    });
+
+    it("due_this_week excludes tasks due beyond 7 days", async () => {
+      const farOut = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
+      const created = await callTool("create_task", {
+        title: "Far future due date test xyz987",
+        scope: "work",
+        due_date: farOut,
+      });
+
+      await callTool("store_handoff", {});
+      const result = await callTool("get_latest_handoff", {});
+      const ts = result.task_summary;
+
+      expect(ts.due_this_week.every((i: any) => i.id !== created.id)).toBe(true);
+    });
+
+    it("recently_completed is ordered newest first", async () => {
+      const first = await callTool("create_task", {
+        title: "Complete-order-first",
+        scope: "work",
+      });
+      await callTool("update_task", { id: first.id, action: "complete" });
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      const second = await callTool("create_task", {
+        title: "Complete-order-second",
+        scope: "work",
+      });
+      await callTool("update_task", { id: second.id, action: "complete" });
+
+      await callTool("store_handoff", {});
+      const result = await callTool("get_latest_handoff", {});
+      const rc = result.task_summary.recently_completed;
+
+      const firstIdx = rc.findIndex((i: any) => i.id === first.id);
+      const secondIdx = rc.findIndex((i: any) => i.id === second.id);
+      expect(secondIdx).toBeGreaterThanOrEqual(0);
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeLessThan(firstIdx);
+    });
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { config } from "./config.js";
 import { registerHandoffTools } from "./tools/handoff.js";
+import { registerHandoffNavTools } from "./tools/handoff-nav.js";
 import { registerTaskTools } from "./tools/tasks.js";
 import { registerSearchTools } from "./tools/search.js";
 import { ensureDataDir } from "./storage/json-store.js";
@@ -79,6 +80,7 @@ function createMcpServer(): McpServer {
     version,
   });
   registerHandoffTools(server);
+  registerHandoffNavTools(server);
   registerTaskTools(server);
   registerSearchTools(server);
   return server;

--- a/src/tools/handoff-nav.ts
+++ b/src/tools/handoff-nav.ts
@@ -1,0 +1,220 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { read } from "../storage/json-store.js";
+import type { Handoff } from "../storage/schemas.js";
+import {
+  HANDOFFS_DIR,
+  SCHEMA_VERSION,
+  computeElapsedSeconds,
+  computeSameCalendarDay,
+  computeTaskSummary,
+  filterByScope,
+  formatStoredAtLocal,
+  localIsoTimestamp,
+} from "./handoff.js";
+import { computeDynamicTaskSummary } from "./task-summary.js";
+
+const FILENAME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-[0-9a-f]+\.json$/;
+
+/** Parse a handoff filename prefix (YYYY-MM-DDThh-mm-ss-mssZ) back into an ISO-8601 timestamp. */
+function parseFilenameTimestamp(filename: string): string | null {
+  const match = filename.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z/);
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s, ms] = match;
+  return `${y}-${mo}-${d}T${h}:${mi}:${s}.${ms}Z`;
+}
+
+function jsonResponse(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
+
+// ── Tool Descriptions ──────────────────────────────────────────────
+
+const LIST_HANDOFFS_DESCRIPTION = `List historical handoffs as metadata (NOT full content). Use this to discover which handoff to retrieve via get_handoff when the user references a session by date or label. Results sort by stored_at descending (newest first).
+
+This complements get_latest_handoff: use get_latest_handoff for the current session boundary, list_handoffs + get_handoff for digging into past sessions.
+
+Parameters:
+- limit (optional, default 10, max 50): Page size
+- offset (optional, default 0): Pagination offset
+- after (optional): ISO date/timestamp — only include handoffs stored after this
+- before (optional): ISO date/timestamp — only include handoffs stored before this
+
+Returns: {handoffs: [{filename, stored_at, session_label, size_bytes, has_tasks, schema_version}], total_count, limit, offset}
+
+The metadata is intentionally lightweight. Call get_handoff with a filename to load full content for a specific entry.`;
+
+const GET_HANDOFF_DESCRIPTION = `Retrieve a specific historical handoff by filename (obtained from list_handoffs). Returns the same enriched response shape as get_latest_handoff, including elapsed_seconds, task_summary, and scope filtering.
+
+Use this after list_handoffs identifies the target session. For the most recent handoff, use get_latest_handoff directly — it's faster than listing then fetching.
+
+Parameters:
+- filename (required): Exact filename from list_handoffs (must not contain '/' or '..')
+- scope (optional, default "full"): "full" | "work" | "personal" — same semantics as get_latest_handoff
+
+Returns: The handoff content filtered by scope plus retrieved_at, elapsed_seconds, same_calendar_day, task_summary, applied_scope, filtered_fields (if scope != full), schema_version.
+
+Errors: Returns {error: true, code: "NOT_FOUND"} if the filename doesn't exist or fails validation.`;
+
+// ── Tool Registration ──────────────────────────────────────────────
+
+export function registerHandoffNavTools(mcpServer: McpServer): void {
+  // ── list_handoffs ──────────────────────────────────────────────
+  mcpServer.tool(
+    "list_handoffs",
+    LIST_HANDOFFS_DESCRIPTION,
+    {
+      limit: z.number().min(1).max(50).optional().default(10),
+      offset: z.number().min(0).optional().default(0),
+      after: z.string().optional().describe("ISO date — handoffs stored after this date"),
+      before: z.string().optional().describe("ISO date — handoffs stored before this date"),
+    },
+    async (args) => {
+      const limit = args.limit ?? 10;
+      const offset = args.offset ?? 0;
+      const afterMs = args.after ? Date.parse(args.after) : null;
+      const beforeMs = args.before ? Date.parse(args.before) : null;
+
+      const dir = HANDOFFS_DIR();
+      let entries: string[];
+      try {
+        entries = (await readdir(dir)).filter(
+          (f) => f.endsWith(".json") && !f.startsWith(".tmp-")
+        );
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return jsonResponse({ handoffs: [], total_count: 0, limit, offset });
+        }
+        throw err;
+      }
+
+      // Build { filename, storedAt } pairs and apply date filters
+      const dated: Array<{ filename: string; storedAt: string; storedAtMs: number }> = [];
+      for (const filename of entries) {
+        const storedAt = parseFilenameTimestamp(filename);
+        if (!storedAt) continue;
+        const storedAtMs = Date.parse(storedAt);
+        if (afterMs !== null && !isNaN(afterMs) && storedAtMs <= afterMs) continue;
+        if (beforeMs !== null && !isNaN(beforeMs) && storedAtMs >= beforeMs) continue;
+        dated.push({ filename, storedAt, storedAtMs });
+      }
+
+      // Sort descending (newest first)
+      dated.sort((a, b) => b.storedAtMs - a.storedAtMs);
+
+      const totalCount = dated.length;
+      const page = dated.slice(offset, offset + limit);
+
+      const handoffs = await Promise.all(
+        page.map(async ({ filename, storedAt }) => {
+          const filepath = join(dir, filename);
+          let sizeBytes = 0;
+          try {
+            sizeBytes = (await stat(filepath)).size;
+          } catch {
+            // Missing/unreadable — treat as 0
+          }
+
+          let sessionLabel: string | null = null;
+          let hasTasks = false;
+          let schemaVersion: string | null = null;
+          try {
+            const handoff = await read<Record<string, unknown>>(filepath);
+            if (handoff) {
+              const activeContext = handoff.active_context as Record<string, unknown> | undefined;
+              const sessionMeta = activeContext?.session_meta as Record<string, unknown> | undefined;
+              if (sessionMeta && typeof sessionMeta.label === "string") {
+                sessionLabel = sessionMeta.label;
+              }
+              hasTasks = handoff.tasks !== undefined && handoff.tasks !== null;
+              if (typeof handoff.schema_version === "string") {
+                schemaVersion = handoff.schema_version;
+              }
+            }
+          } catch {
+            // Corrupt or unreadable file — leave fields as defaults
+          }
+
+          return {
+            filename,
+            stored_at: storedAt,
+            session_label: sessionLabel,
+            size_bytes: sizeBytes,
+            has_tasks: hasTasks,
+            schema_version: schemaVersion,
+          };
+        })
+      );
+
+      return jsonResponse({
+        handoffs,
+        total_count: totalCount,
+        limit,
+        offset,
+      });
+    }
+  );
+
+  // ── get_handoff ────────────────────────────────────────────────
+  mcpServer.tool(
+    "get_handoff",
+    GET_HANDOFF_DESCRIPTION,
+    {
+      filename: z.string().describe("Exact handoff filename from list_handoffs"),
+      scope: z
+        .enum(["full", "work", "personal"])
+        .optional()
+        .default("full")
+        .describe("Filter scope: 'full' (default), 'work', or 'personal'"),
+    },
+    async (args) => {
+      // Path traversal prevention: reject any filename with separators or parent refs
+      if (
+        !args.filename ||
+        args.filename.includes("/") ||
+        args.filename.includes("\\") ||
+        args.filename.includes("..") ||
+        !FILENAME_PATTERN.test(args.filename)
+      ) {
+        return jsonResponse({
+          error: true,
+          code: "NOT_FOUND",
+          message: "Invalid or unknown filename",
+        });
+      }
+
+      const filepath = join(HANDOFFS_DIR(), args.filename);
+      const handoff = await read<Handoff>(filepath);
+      if (!handoff) {
+        return jsonResponse({
+          error: true,
+          code: "NOT_FOUND",
+          message: "Handoff not found",
+        });
+      }
+
+      const scope = args.scope ?? "full";
+      const { result: filtered, filteredFields } = filterByScope(handoff, scope);
+
+      // Prefer dynamic (Postgres) summary; fall back to handoff-based counts
+      const dynamic = await computeDynamicTaskSummary();
+      const taskSummary = dynamic ?? computeTaskSummary(handoff);
+
+      return jsonResponse({
+        ...filtered,
+        retrieved_at: localIsoTimestamp(handoff.timezone),
+        elapsed_seconds: computeElapsedSeconds(handoff.stored_at),
+        same_calendar_day: computeSameCalendarDay(handoff.stored_at, handoff.timezone),
+        task_summary: taskSummary,
+        applied_scope: scope,
+        ...(scope !== "full" ? { filtered_fields: filteredFields } : {}),
+        stored_at_local: formatStoredAtLocal(handoff.stored_at ?? "", handoff.timezone),
+        schema_version: SCHEMA_VERSION,
+      });
+    }
+  );
+}

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -6,13 +6,14 @@ import { read, writeHandoff, getLatestHandoffFilename, getHandoffCount } from ".
 import type { Handoff } from "../storage/schemas.js";
 import { mergeHandoff } from "./merge.js";
 import { indexHandoff } from "../embeddings/indexer.js";
+import { computeDynamicTaskSummary } from "./task-summary.js";
 
-const SCHEMA_VERSION = "1.1";
+export const SCHEMA_VERSION = "1.1";
 
-const HANDOFFS_DIR = () => join(config.dataDir, "handoffs");
+export const HANDOFFS_DIR = () => join(config.dataDir, "handoffs");
 
 /** Format current time as ISO-8601 with timezone offset. Uses IANA timezone if provided, otherwise server-local. */
-function localIsoTimestamp(tz?: string): string {
+export function localIsoTimestamp(tz?: string): string {
   const now = new Date();
 
   if (tz) {
@@ -57,7 +58,7 @@ function localIsoTimestamp(tz?: string): string {
 }
 
 /** Format a stored_at timestamp in the handoff's timezone for convenience display. */
-function formatStoredAtLocal(storedAt: string, tz?: string): string | null {
+export function formatStoredAtLocal(storedAt: string, tz?: string): string | null {
   if (!storedAt || !tz) return null;
   try {
     const date = new Date(storedAt);
@@ -79,7 +80,7 @@ function formatStoredAtLocal(storedAt: string, tz?: string): string | null {
 }
 
 /** Compute task_summary from handoff data. */
-function computeTaskSummary(handoff: Handoff) {
+export function computeTaskSummary(handoff: Handoff) {
   return {
     open_count: (handoff.tasks?.open || []).length,
     blocked_count: (handoff.tasks?.blocked || []).length,
@@ -88,7 +89,7 @@ function computeTaskSummary(handoff: Handoff) {
 }
 
 /** Compute elapsed_seconds since stored_at. Returns null if stored_at is missing/unparseable. */
-function computeElapsedSeconds(storedAt?: string): number | null {
+export function computeElapsedSeconds(storedAt?: string): number | null {
   if (!storedAt) return null;
   const parsed = Date.parse(storedAt);
   if (isNaN(parsed)) return null;
@@ -96,7 +97,7 @@ function computeElapsedSeconds(storedAt?: string): number | null {
 }
 
 /** Compute same_calendar_day using the handoff's timezone. */
-function computeSameCalendarDay(storedAt?: string, tz?: string): boolean {
+export function computeSameCalendarDay(storedAt?: string, tz?: string): boolean {
   if (!storedAt) return false;
   const timezone = tz || "UTC";
   try {
@@ -109,7 +110,7 @@ function computeSameCalendarDay(storedAt?: string, tz?: string): boolean {
 }
 
 /** Filter a handoff payload by scope, tracking which fields were removed. */
-function filterByScope(
+export function filterByScope(
   handoff: Handoff,
   scope: "full" | "work" | "personal"
 ): { result: Record<string, unknown>; filteredFields: string[] } {
@@ -211,6 +212,11 @@ WHEN TO CALL: At session start (always), before any store_handoff or patch_hando
 Pre-computed fields: elapsed_seconds, same_calendar_day (if false, operational_state is stale — confirm with user), task_summary, applied_scope/filtered_fields, schema_version, handoff_count, stored_at_local, evidence_pulled.
 
 Response shape: operational_state, active_context, tasks, task_summary, tone_notes (read before responding), timezone, stored_at, retrieved_at, elapsed_seconds, same_calendar_day, schema_version, handoff_count, evidence_pulled.
+
+task_summary shape:
+When Postgres is available, task_summary is computed live from the authoritative tasks table and returns:
+{open_count, blocked_count, completed_count, critical_items: [{id, title, due_date}], due_this_week: [{id, title, due_date}], recently_completed: [{id, title, completed_at}], blocked_items: [{id, title, blocked_reason}]}
+When Postgres is unavailable, task_summary falls back to counts derived from the handoff's own tasks arrays: {open_count, blocked_count, completed_count}.
 
 SessionEvidence:
 evidence_pulled indicates whether operational context was successfully loaded.
@@ -383,6 +389,10 @@ export function registerHandoffTools(mcpServer: McpServer): void {
       const { result: filtered, filteredFields } = filterByScope(handoff, scope);
       const handoffCount = await getHandoffCount();
 
+      // Prefer enriched task summary from Postgres; fall back to handoff-array counts when unavailable
+      const dynamicSummary = await computeDynamicTaskSummary();
+      const taskSummary = dynamicSummary ?? computeTaskSummary(handoff);
+
       return {
         content: [
           {
@@ -392,7 +402,7 @@ export function registerHandoffTools(mcpServer: McpServer): void {
               retrieved_at: localIsoTimestamp(handoff.timezone),
               elapsed_seconds: computeElapsedSeconds(handoff.stored_at),
               same_calendar_day: computeSameCalendarDay(handoff.stored_at, handoff.timezone),
-              task_summary: computeTaskSummary(handoff),
+              task_summary: taskSummary,
               applied_scope: scope,
               ...(scope !== "full" ? { filtered_fields: filteredFields } : {}),
               stored_at_local: formatStoredAtLocal(handoff.stored_at ?? "", handoff.timezone),

--- a/src/tools/task-summary.ts
+++ b/src/tools/task-summary.ts
@@ -1,0 +1,131 @@
+import { query } from "../db/client.js";
+
+export interface DynamicTaskSummary {
+  open_count: number;
+  blocked_count: number;
+  completed_count: number;
+  critical_items: Array<{ id: string; title: string; due_date: string | null }>;
+  due_this_week: Array<{ id: string; title: string; due_date: string }>;
+  recently_completed: Array<{ id: string; title: string; completed_at: string }>;
+  blocked_items: Array<{ id: string; title: string; blocked_reason: string }>;
+}
+
+interface CountRow {
+  status: string;
+  count: string;
+}
+
+interface BlockedCountRow {
+  count: string;
+}
+
+interface CriticalRow {
+  id: string;
+  title: string;
+  due_date: string | null;
+}
+
+interface DueRow {
+  id: string;
+  title: string;
+  due_date: string;
+}
+
+interface CompletedRow {
+  id: string;
+  title: string;
+  completed_at: string;
+}
+
+interface BlockedItemRow {
+  id: string;
+  title: string;
+  blocked_reason: string;
+}
+
+/**
+ * Compute the enriched task_summary from Postgres. Returns null if Postgres is
+ * unavailable or any query fails, allowing callers to fall back to the
+ * handoff-based count summary.
+ */
+export async function computeDynamicTaskSummary(): Promise<DynamicTaskSummary | null> {
+  try {
+    const [counts, blockedCount, critical, dueThisWeek, recentlyCompleted, blockedItems] =
+      await Promise.all([
+        query<CountRow>(
+          `SELECT status::text AS status, count(*)::text AS count
+           FROM tasks
+           WHERE status IN ('open', 'completed')
+           GROUP BY status`
+        ),
+        query<BlockedCountRow>(
+          `SELECT count(*)::text AS count
+           FROM tasks
+           WHERE blocked_reason IS NOT NULL AND status = 'open'`
+        ),
+        query<CriticalRow>(
+          `SELECT id, title, due_date
+           FROM tasks
+           WHERE status = 'open' AND priority = 'critical'
+           ORDER BY due_date ASC NULLS LAST
+           LIMIT 5`
+        ),
+        query<DueRow>(
+          `SELECT id, title, due_date
+           FROM tasks
+           WHERE status = 'open'
+             AND due_date BETWEEN NOW() AND NOW() + INTERVAL '7 days'
+           ORDER BY due_date ASC`
+        ),
+        query<CompletedRow>(
+          `SELECT id, title, completed_at
+           FROM tasks
+           WHERE status = 'completed'
+           ORDER BY completed_at DESC NULLS LAST
+           LIMIT 5`
+        ),
+        query<BlockedItemRow>(
+          `SELECT id, title, blocked_reason
+           FROM tasks
+           WHERE status = 'open' AND blocked_reason IS NOT NULL
+           ORDER BY created_at DESC`
+        ),
+      ]);
+
+    let openCount = 0;
+    let completedCount = 0;
+    for (const row of counts.rows) {
+      const n = parseInt(row.count, 10);
+      if (row.status === "open") openCount = n;
+      else if (row.status === "completed") completedCount = n;
+    }
+
+    return {
+      open_count: openCount,
+      blocked_count: parseInt(blockedCount.rows[0]?.count ?? "0", 10),
+      completed_count: completedCount,
+      critical_items: critical.rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        due_date: r.due_date,
+      })),
+      due_this_week: dueThisWeek.rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        due_date: r.due_date,
+      })),
+      recently_completed: recentlyCompleted.rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        completed_at: r.completed_at,
+      })),
+      blocked_items: blockedItems.rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        blocked_reason: r.blocked_reason,
+      })),
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Implements v0.6 batch 2 — handoff navigation and task enrichment.

- **`list_handoffs`** — MCP tool returning handoff metadata (filename, stored_at, session_label, size_bytes, has_tasks, schema_version) with pagination and `after`/`before` date filters. Sorted newest-first.
- **`get_handoff`** — MCP tool retrieving a specific historical handoff by filename, with scope filtering and path-traversal prevention. Returns the same enriched envelope as `get_latest_handoff`.
- **Dynamic `task_summary`** — `get_latest_handoff` now computes `task_summary` live from Postgres: counts plus `critical_items`, `due_this_week`, `recently_completed`, and `blocked_items` arrays. Falls back to handoff-array counts when Postgres is unavailable (preserves Tier 1 compatibility).

Shared handoff helpers (`filterByScope`, `computeTaskSummary`, `computeElapsedSeconds`, `computeSameCalendarDay`, `localIsoTimestamp`, `formatStoredAtLocal`) were exported from `handoff.ts` for reuse; behavior is unchanged.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 102 passed / 32 skipped (Postgres suite skipped in local env)
- [x] New tests cover: tool listing, metadata shape, newest-first ordering, pagination, `after`/`before` filtering, `session_label` + `has_tasks` extraction, scope filtering on `get_handoff`, `NOT_FOUND` error path, path-traversal rejection
- [x] New Postgres-gated tests cover: enriched `task_summary` shape from live DB, `due_this_week` 7-day window, `recently_completed` ordering
- [x] Postgres-dependent tests run in CI where the DB is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)