### PR TITLE
feat: v0.7.0 — artifact layer (fourth primitive) + embedding resilience fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/onideus/context-library)](https://github.com/onideus/context-library/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-A personal MCP server that provides persistent operational context, task management, knowledge capture, and semantic search across AI assistant sessions. Model-agnostic, Docker-ready, designed for single-user cognitive infrastructure.
+A personal MCP server that provides persistent operational context, task management, knowledge capture, artifact tracking, and semantic search across AI assistant sessions. Model-agnostic, Docker-ready, designed for single-user cognitive infrastructure.
 
 ## What It Does
 
@@ -29,15 +29,15 @@ docker compose up -d
 
 > Handoff files are retained indefinitely by default. To enable automatic pruning of old handoffs, set `RETENTION_COUNT` to a positive number (e.g., `5000`).
 
-### Tier 2: + PostgreSQL (Tasks + Knowledge + Full-Text Search)
+### Tier 2: + PostgreSQL (Tasks + Knowledge + Artifacts + Full-Text Search)
 
-Adds structured task management, permanent knowledge capture, and full-text search. Requires PostgreSQL 16 with pgvector.
+Adds structured task management, permanent knowledge capture, generated-output tracking, and full-text search. Requires PostgreSQL 16 with pgvector.
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
 ```
 
-**Additional tools:** `create_task`, `get_task`, `list_tasks`, `update_task`, `search_tasks`, `create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note`
+**Additional tools:** `create_task`, `get_task`, `list_tasks`, `update_task`, `search_tasks`, `create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note`, `store_artifact`, `get_artifact`, `list_artifacts`, `search_artifacts`, `update_artifact`
 
 ### Tier 3: + Embeddings (Semantic Search)
 
@@ -92,12 +92,12 @@ When the reranker is not configured or unreachable, `search_context` falls back 
 - **Server:** Hono 4.x + StreamableHTTP MCP transport (Node.js 22, TypeScript)
 - **Storage (Tier 1):** Append-only JSON files in `./data/handoffs/`
 - **Database (Tier 2):** PostgreSQL 16 with pgvector extension
-- **Content primitives:** Handoffs (ephemeral session state), Tasks (lifecycle-managed action items), Notes (permanent knowledge — decisions, patterns, insights)
+- **Content primitives:** Handoffs (ephemeral session state), Tasks (lifecycle-managed action items), Notes (permanent knowledge — decisions, patterns, insights), Artifacts (generated outputs with lifecycle state and execution ordering)
 - **Embeddings (Tier 3):** Text Embeddings Inference with nomic-embed-text-v2-moe (768 dims), optional cross-encoder reranker
 - **Search:** Hybrid retrieval (vector + FTS with RRF fusion), optional cross-encoder reranking, entity-aware context envelopes, search alias expansion, date-range filtering
 - **Auth:** Handled externally by [mcp-auth-proxy](https://github.com/sigbit/mcp-auth-proxy) — the server itself is unauthenticated and trusts its network boundary
 
-Each component degrades gracefully when unavailable. If Postgres is down, handoffs still work. If the embedding server is unreachable, task and note search still works via full-text search.
+Each component degrades gracefully when unavailable. If Postgres is down, handoffs still work. If the embedding server is unreachable, task, note, and artifact search still works via full-text search; failed embeddings are queued for automatic retry when TEI comes back.
 
 ## MCP Tools
 
@@ -119,8 +119,13 @@ Each component degrades gracefully when unavailable. If Postgres is down, handof
 | `search_notes` | Postgres | Full-text search across note titles and content |
 | `update_note` | Postgres | Update note fields; re-embeds on content change |
 | `delete_note` | Postgres | Permanently delete a note and its embedding |
+| `store_artifact` | Postgres | Capture a generated output (CC prompt, research, template) with lifecycle state |
+| `get_artifact` | Postgres | Retrieve artifact by UUID (full content + pointer + metadata) |
+| `list_artifacts` | Postgres | Browse artifacts with type, status, scope, and tag filters; execution_order-aware sort |
+| `search_artifacts` | Postgres | Full-text search across artifact titles and content |
+| `update_artifact` | Postgres | Update artifact fields; enforces status transitions; re-embeds on content change |
 | `search_context` | Embeddings | Hybrid semantic search (vector + FTS with RRF fusion) across all content types |
-| `reindex` | Embeddings | Rebuild semantic search index for handoffs, tasks, and notes |
+| `reindex` | Embeddings | Rebuild semantic search index for handoffs, tasks, notes, and artifacts |
 
 ## Health Checks
 
@@ -133,7 +138,7 @@ Both return JSON. Use `/health` for uptime monitoring and `/health/ready` after 
 
 ```bash
 curl http://localhost:3100/health
-# {"status":"ok","version":"0.5.4","uptime":42}
+# {"status":"ok","version":"0.7.0","uptime":42}
 
 curl http://localhost:3100/health/ready
 # {"status":"ok","archive":true,"uptime":42}
@@ -248,7 +253,7 @@ After connecting, ask your AI assistant to call `get_latest_handoff`. If it retu
 
 ```bash
 curl http://localhost:3100/health
-# {"status":"ok","version":"0.5.4","uptime":42}
+# {"status":"ok","version":"0.7.0","uptime":42}
 ```
 
 ## External Access with Auth Proxy
@@ -318,8 +323,8 @@ Insecure images never reach the registry — Snyk gates the push. By the time a 
 **To cut a release:**
 
 ```bash
-git tag v0.5.4
-git push origin v0.5.4
+git tag v0.7.0
+git push origin v0.7.0
 ```
 
 Old SHA-tagged images are pruned weekly (90-day retention), preserving any image referenced by a release tag.
@@ -407,7 +412,7 @@ If you see `Postgres migrations skipped — database not available`, the server 
 
 ## Security
 
-This server holds personal operational data — handoff state, tasks, knowledge entries, execution logs. It is designed to run behind a reverse proxy that handles authentication. **Never expose the MCP server directly to the internet.**
+This server holds personal operational data — handoff state, tasks, knowledge entries, artifacts, execution logs. It is designed to run behind a reverse proxy that handles authentication. **Never expose the MCP server directly to the internet.**
 
 > **Note:** When using the auth proxy overlay (`docker-compose.auth.yml`), the MCP server still binds to `127.0.0.1:3100` from the base compose file. This means the unauthenticated server remains accessible on localhost. This is intentional for local debugging but should be considered in your deployment security model. A future release will address this in the overlay.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,15 @@
 # Context Library — Roadmap
 
-## Design Philosophy: Three Primitives
+## Design Philosophy: Four Primitives
 
-Context Library is built around three distinct data types that map to three questions:
+Context Library is built around four distinct data types that map to four questions:
 
 - **Handoffs** → *Where am I?* — Operational state captured at session boundaries. Ephemeral, append-only, scoped by time.
 - **Tasks** → *What do I need to do?* — Action items with lifecycles (open → completed/cancelled/deferred). Queryable, filterable, finite.
-- **Knowledge** *(planned)* → *What do I know?* — Captured thinking, article takeaways, pattern recognition, connections between ideas. Accrues indefinitely. No status lifecycle. Retrieved by meaning, not by deadline.
+- **Knowledge** → *What do I know?* — Captured thinking, article takeaways, pattern recognition, connections between ideas. Accrues indefinitely. No status lifecycle. Retrieved by meaning, not by deadline.
+- **Artifacts** → *What have I produced?* — Generated outputs (CC prompts, research, blog posts, templates) with a lifecycle (draft → ready → executing → completed) and execution ordering. Bridges planning and execution sessions.
 
-All three primitives share a unified semantic search index (pgvector + FTS with RRF fusion), enabling cross-type retrieval: a search for "authentication architecture" returns relevant handoff context, open tasks, and accumulated knowledge together.
+All four primitives share a unified semantic search index (pgvector + FTS with RRF fusion), enabling cross-type retrieval: a search for "authentication architecture" returns relevant handoff context, open tasks, accumulated knowledge, and related artifacts together.
 
 ## Completed
 
@@ -40,9 +41,9 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - CLAUDE.md Personal Data Prohibition section for OSS safety
 - TEI compose profiles for GPU (NVIDIA CUDA) and CPU deployment
 
-> **Note on version gaps:** Tags v0.5.2 and v0.5.3 were consumed during release pipeline testing (Snyk container scan failures). v0.5.4-rc.0 and v0.5.4-test.1 verified the new promotion model. The next release is v0.5.4.
+> **Note on version gaps:** Tags v0.5.2 and v0.5.3 were consumed during release pipeline testing (Snyk container scan failures). v0.5.4-rc.0 and v0.5.4-test.1 verified the new promotion model.
 
-## Current: v0.5.4 — Server-Side Enforcement & Cleanup
+### v0.5.4 — Server-Side Enforcement & Cleanup
 
 - `evidence_pulled` field for judgment-class request gating (advisory, not blocking)
 - Per-model response format tuning in tool descriptions
@@ -51,26 +52,31 @@ All three primitives share a unified semantic search index (pgvector + FTS with 
 - `z.any()` → `z.unknown()` migration in handoff schemas and tool parameters
 - Docker Compose embeddings port mapping for externalized TEI deployments
 - Tool description updates for new capabilities
-- Version bump to 0.5.4
 
-## Next: v0.6 — Resilience, Retrieval & Knowledge
+### v0.6 — Resilience, Retrieval & Knowledge
 
-Focus: make the system self-healing, observable, harder to misuse — and introduce the third primitive.
-
-- **Knowledge layer (third primitive):** `notes` table in PostgreSQL with MCP tools (`create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note`); embedded into pgvector for unified semantic search; `'note'` added to `search_context` `content_types`; distinct from artifacts — knowledge is interpretation, not output
+- **Knowledge layer (third primitive):** `notes` table in PostgreSQL with MCP tools (`create_note`, `get_note`, `list_notes`, `search_notes`, `update_note`, `delete_note`); embedded into pgvector for unified semantic search; `'note'` added to `search_context` `content_types`
 - **Embedding resilience:** `embedding_status` field in `get_latest_handoff` response (TEI health + pending count); pending embeddings queue with dead-letter pattern for TEI outage recovery (O(k) recovery vs O(n) full reindex)
 - **Handoff navigation:** `list_handoffs` and `get_handoff` MCP tools for historical handoff browsing and retrieval
 - **Dynamic task summary:** Server-side computed task summary in `get_latest_handoff` — critical items, due this week, recently completed, blocked chains (replaces basic counts)
 - **Security hardening:** Scope enforcement on task tools (propagate handoff scope as session default); input size limits on store/patch/create operations
-- **Retrieval quality:** Cross-encoder rerank stage after RRF fusion (TEI with MiniLM, ~30-50 lines in search.ts); search alias expansion table for abbreviation/term mapping; entity word-boundary matching; date-range filtering on `search_context`
+- **Retrieval quality:** Cross-encoder rerank stage after RRF fusion (TEI with MiniLM); search alias expansion table for abbreviation/term mapping; entity word-boundary matching; date-range filtering on `search_context`
 - **Automated handoff compaction:** Session-boundary pruning with vector archival — keeps handoffs small, history searchable
 - **Schema hygiene:** `schema_version` field on handoffs for forward/backward compatibility
 
-## Future: v0.7 — New Primitives
+## Current: v0.7.0 — Artifact Layer & Embedding Resilience Fix
 
-Focus: expand beyond the three primitives into richer structure and artifact storage.
+Focus: introduce the fourth primitive and close the last gap in pending-queue resilience.
 
-- **Artifact storage:** File/content tracking with metadata, SHA-256 hashing, and versioning; prompt library via tagging convention
+- **Artifact layer (fourth primitive):** `artifacts` table in PostgreSQL with MCP tools (`store_artifact`, `get_artifact`, `list_artifacts`, `search_artifacts`, `update_artifact`); lifecycle state (draft → ready → executing → completed → superseded) with enforced transitions; `execution_order` for sequenced prompt chains; inline content or external pointer (git/local/url); `'artifact'` added to `search_context` and `reindex` `content_types`
+- **Embedding resilience (bug fix #37):** `indexNote` and `indexArtifact` now use the same TEI-connectivity → pending-queue fallback as `indexHandoff`/`indexTask`; `drainPendingEmbeddings` handles all four content types; `pending_embeddings` CHECK constraint expanded in migration `007`
+- **Tooling hygiene:** `mergeEntities` split out of `scripts/extract-entities.ts` into `scripts/merge-entities.ts` so its tests no longer require the `@anthropic-ai/sdk` devDependency to load
+
+## Future: v0.8 — Primitive Evolution
+
+Focus: deepen the four primitives with richer structure and cross-primitive linking.
+
+- **Artifact versioning & hashing:** SHA-256 content hashing and version chains for artifacts (supersedes relationships beyond the flat `superseded` status)
 - **Task schema evolution:** Subtasks (parent_id), relations (blocks/blocked-by/related), custom fields (JSONB UDAs); hierarchy is opt-in, flat tasks remain the default
 - **Bitemporal entity constraints:** `valid_from`/`valid_until` on entities to prevent stale constraint application
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-library",
-  "version": "0.5.4-rc.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-library",
-      "version": "0.5.4-rc.0",
+      "version": "0.7.0",
       "dependencies": {
         "@hono/mcp": "^0.2.4",
         "@hono/node-server": "^1.19.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-library",
-  "version": "0.5.4",
+  "version": "0.7.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/scripts/extract-entities.test.ts
+++ b/scripts/extract-entities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mergeEntities } from "./extract-entities.js";
+import { mergeEntities } from "./merge-entities.js";
 
 // ── mergeEntities: idempotent merge logic ─────────────────────────
 

--- a/scripts/extract-entities.ts
+++ b/scripts/extract-entities.ts
@@ -28,21 +28,14 @@ import { readdir, readFile, writeFile, access } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
+import { mergeEntities, type EntitySeed, type Scope } from "./merge-entities.js";
+
+export { mergeEntities, type EntitySeed, type Scope } from "./merge-entities.js";
 
 const DEFAULT_MODEL = "claude-sonnet-4-20250514";
 const BATCH_SIZE = 8;
 
 // ── Types ─────────────────────────────────────────────────────────
-
-type Scope = "work" | "personal" | "shared";
-
-interface EntitySeed {
-  canonical_name: string;
-  scope: Scope;
-  aliases: string[];
-  constraints: string[];
-  confidence?: number;
-}
 
 interface Summary {
   handoffs_read: number;
@@ -121,77 +114,8 @@ async function readExistingSeed(path: string): Promise<EntitySeed[]> {
 }
 
 // ── Merge logic (pure, testable) ──────────────────────────────────
-
-/**
- * Idempotent merge of freshly extracted entities into an existing seed list.
- * - New entities are added.
- * - Existing entities preserve human-edited constraints (constraints are not
- *   overwritten). Aliases are union-merged. Scope is preserved from the
- *   existing entry unless the existing entry has no scope set.
- * - No entry is ever deleted.
- *
- * Comparison is case-insensitive on canonical_name.
- */
-export function mergeEntities(
-  existing: EntitySeed[],
-  fresh: EntitySeed[]
-): { merged: EntitySeed[]; added: number; updated: number; aliasesAdded: number } {
-  const byKey = new Map<string, EntitySeed>();
-  const order: string[] = [];
-
-  for (const e of existing) {
-    const key = e.canonical_name.toLowerCase();
-    byKey.set(key, {
-      canonical_name: e.canonical_name,
-      scope: e.scope,
-      aliases: Array.isArray(e.aliases) ? [...e.aliases] : [],
-      constraints: Array.isArray(e.constraints) ? [...e.constraints] : [],
-      ...(typeof e.confidence === "number" ? { confidence: e.confidence } : {}),
-    });
-    order.push(key);
-  }
-
-  let added = 0;
-  let updated = 0;
-  let aliasesAdded = 0;
-
-  for (const f of fresh) {
-    const key = f.canonical_name.toLowerCase();
-    const current = byKey.get(key);
-    if (!current) {
-      byKey.set(key, {
-        canonical_name: f.canonical_name,
-        scope: f.scope,
-        aliases: Array.isArray(f.aliases) ? [...new Set(f.aliases)] : [],
-        constraints: Array.isArray(f.constraints) ? [...f.constraints] : [],
-        ...(typeof f.confidence === "number" ? { confidence: f.confidence } : {}),
-      });
-      order.push(key);
-      added++;
-      continue;
-    }
-
-    // Union-merge aliases (case-insensitive dedupe, preserve existing casing)
-    const seen = new Set(current.aliases.map((a) => a.toLowerCase()));
-    let changed = false;
-    for (const alias of f.aliases ?? []) {
-      if (!seen.has(alias.toLowerCase())) {
-        current.aliases.push(alias);
-        seen.add(alias.toLowerCase());
-        aliasesAdded++;
-        changed = true;
-      }
-    }
-
-    // Preserve existing constraints. Never overwrite or append fresh
-    // constraints — humans curate those. (New entities get fresh constraints
-    // because there is nothing to preserve yet.)
-    if (changed) updated++;
-  }
-
-  const merged = order.map((k) => byKey.get(k)!);
-  return { merged, added, updated, aliasesAdded };
-}
+// Extracted into ./merge-entities.ts so tests can exercise it without
+// loading the Anthropic SDK. Re-exported at the top of this file.
 
 // ── Prompting ─────────────────────────────────────────────────────
 

--- a/scripts/merge-entities.ts
+++ b/scripts/merge-entities.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure merge logic for the entity seeding pipeline. Extracted from
+ * extract-entities.ts so tests can exercise it without loading the
+ * Anthropic SDK (a devDependency that is not installed in minimal
+ * CI environments).
+ */
+
+export type Scope = "work" | "personal" | "shared";
+
+export interface EntitySeed {
+  canonical_name: string;
+  scope: Scope;
+  aliases: string[];
+  constraints: string[];
+  confidence?: number;
+}
+
+/**
+ * Idempotent merge of fresh LLM-extracted entities into an existing seed list.
+ *
+ * - Adds new entities (case-insensitive canonical_name match).
+ * - Union-merges aliases, preserving existing casing.
+ * - Preserves existing constraints verbatim — humans curate those, so fresh
+ *   LLM-suggested constraints never overwrite or append onto an existing entry.
+ *   New entities get fresh constraints because there is nothing to preserve yet.
+ * - Preserves existing scope — fresh scope assignments never overwrite an
+ *   existing entry unless the existing entry has no scope set.
+ * - Never deletes entries.
+ *
+ * Comparison is case-insensitive on canonical_name.
+ */
+export function mergeEntities(
+  existing: EntitySeed[],
+  fresh: EntitySeed[]
+): { merged: EntitySeed[]; added: number; updated: number; aliasesAdded: number } {
+  const byKey = new Map<string, EntitySeed>();
+  const order: string[] = [];
+
+  for (const e of existing) {
+    const key = e.canonical_name.toLowerCase();
+    byKey.set(key, {
+      canonical_name: e.canonical_name,
+      scope: e.scope,
+      aliases: Array.isArray(e.aliases) ? [...e.aliases] : [],
+      constraints: Array.isArray(e.constraints) ? [...e.constraints] : [],
+      ...(typeof e.confidence === "number" ? { confidence: e.confidence } : {}),
+    });
+    order.push(key);
+  }
+
+  let added = 0;
+  let updated = 0;
+  let aliasesAdded = 0;
+
+  for (const f of fresh) {
+    const key = f.canonical_name.toLowerCase();
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, {
+        canonical_name: f.canonical_name,
+        scope: f.scope,
+        aliases: Array.isArray(f.aliases) ? [...new Set(f.aliases)] : [],
+        constraints: Array.isArray(f.constraints) ? [...f.constraints] : [],
+        ...(typeof f.confidence === "number" ? { confidence: f.confidence } : {}),
+      });
+      order.push(key);
+      added++;
+      continue;
+    }
+
+    // Union-merge aliases (case-insensitive dedupe, preserve existing casing)
+    const seen = new Set(current.aliases.map((a) => a.toLowerCase()));
+    let changed = false;
+    for (const alias of f.aliases ?? []) {
+      if (!seen.has(alias.toLowerCase())) {
+        current.aliases.push(alias);
+        seen.add(alias.toLowerCase());
+        aliasesAdded++;
+        changed = true;
+      }
+    }
+
+    if (changed) updated++;
+  }
+
+  const merged = order.map((k) => byKey.get(k)!);
+  return { merged, added, updated, aliasesAdded };
+}

--- a/src/__tests__/artifacts.test.ts
+++ b/src/__tests__/artifacts.test.ts
@@ -1,0 +1,622 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Artifact tool integration tests.
+ *
+ * Requires a running PostgreSQL instance. See tasks.test.ts for setup.
+ * If Postgres is not available, the entire suite is skipped gracefully
+ * via describe.skipIf at module load (top-level await).
+ */
+
+const TEST_PORT = 3195;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_DATA_DIR = join(process.cwd(), "data", "test-artifacts");
+
+const PG_DATABASE = "cl_test_artifacts";
+const PG_USER = process.env.PGUSER ?? "cl";
+const PG_PASSWORD = process.env.PGPASSWORD ?? "test";
+const PG_HOST = process.env.PGHOST ?? "localhost";
+const PG_PORT = process.env.PGPORT ?? "5432";
+
+let serverProcess: ChildProcess;
+
+async function waitForServer(url: string, timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${url}/health`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Server did not start within ${timeoutMs}ms`);
+}
+
+async function parseSseResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  const dataLine = text.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`No data line in SSE response. Body:\n${text}`);
+  return JSON.parse(dataLine.slice(5).trim());
+}
+
+function jsonrpc(method: string, params?: Record<string, unknown>, id = 1) {
+  return { jsonrpc: "2.0", method, ...(params ? { params } : {}), id };
+}
+
+async function mcpPost(body: unknown) {
+  return fetch(`${BASE_URL}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream, application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callTool(name: string, args: Record<string, unknown> = {}) {
+  const res = await mcpPost(jsonrpc("tools/call", { name, arguments: args }));
+  expect(res.status).toBe(200);
+  const data = (await parseSseResponse(res)) as any;
+  return JSON.parse(data.result.content[0].text);
+}
+
+async function checkPostgres(): Promise<boolean> {
+  try {
+    const pg = await import("pg");
+
+    // Ensure the test database exists — connect to default 'postgres' first.
+    const admin = new pg.default.Client({
+      host: PG_HOST,
+      port: parseInt(PG_PORT),
+      user: PG_USER,
+      password: PG_PASSWORD,
+      database: "postgres",
+    });
+    await admin.connect();
+    const exists = await admin.query(
+      "SELECT 1 FROM pg_database WHERE datname = $1",
+      [PG_DATABASE]
+    );
+    if (exists.rowCount === 0) {
+      await admin.query(`CREATE DATABASE ${PG_DATABASE}`);
+    }
+    await admin.end();
+
+    const client = new pg.default.Client({
+      host: PG_HOST,
+      port: parseInt(PG_PORT),
+      user: PG_USER,
+      password: PG_PASSWORD,
+      database: PG_DATABASE,
+    });
+    await client.connect();
+
+    // Clean slate for test isolation
+    await client.query("DROP TABLE IF EXISTS artifacts CASCADE");
+    await client.query("DROP TABLE IF EXISTS notes CASCADE");
+    await client.query("DROP TABLE IF EXISTS tasks CASCADE");
+    await client.query("DROP TABLE IF EXISTS embeddings CASCADE");
+    await client.query("DROP TABLE IF EXISTS pending_embeddings CASCADE");
+    await client.query("DROP TABLE IF EXISTS _migrations CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_status CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_scope CASCADE");
+    await client.query("DROP TYPE IF EXISTS task_priority CASCADE");
+
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const pgAvailable = await checkPostgres();
+
+if (!pgAvailable) {
+  console.log("\n" + "=".repeat(60));
+  console.log("  NOTICE: PostgreSQL not available");
+  console.log("  Artifact Tools suite will be SKIPPED");
+  console.log("=".repeat(60) + "\n");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────
+
+describe.skipIf(!pgAvailable)("Artifact Tools", () => {
+  beforeAll(async () => {
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+    await mkdir(TEST_DATA_DIR, { recursive: true });
+
+    serverProcess = spawn("npx", ["tsx", "src/server.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MCP_PORT: String(TEST_PORT),
+        DATA_DIR: TEST_DATA_DIR,
+        PGHOST: PG_HOST,
+        PGPORT: PG_PORT,
+        PGUSER: PG_USER,
+        PGPASSWORD: PG_PASSWORD,
+        PGDATABASE: PG_DATABASE,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: true,
+    });
+
+    // Uncomment for debugging:
+    // serverProcess.stderr?.on("data", (d) => process.stderr.write(d));
+    // serverProcess.stdout?.on("data", (d) => process.stdout.write(d));
+
+    await waitForServer(BASE_URL);
+  }, 20_000);
+
+  afterAll(async () => {
+    if (serverProcess) {
+      serverProcess.kill("SIGTERM");
+      await new Promise((r) => setTimeout(r, 500));
+      if (!serverProcess.killed) serverProcess.kill("SIGKILL");
+    }
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  it("artifact tools appear in tools/list", async () => {
+    const res = await mcpPost(jsonrpc("tools/list"));
+    const data = (await parseSseResponse(res)) as any;
+    const toolNames: string[] = data.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain("store_artifact");
+    expect(toolNames).toContain("get_artifact");
+    expect(toolNames).toContain("list_artifacts");
+    expect(toolNames).toContain("search_artifacts");
+    expect(toolNames).toContain("update_artifact");
+  });
+
+  describe("store_artifact", () => {
+    it("creates an inline-content artifact with all fields", async () => {
+      const result = await callTool("store_artifact", {
+        title: "CC prompt: migrate auth",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "Plan and execute the auth migration in 3 phases...",
+        status: "ready",
+        tags: ["auth", "migration"],
+        execution_order: 1,
+        metadata: { branch_target: "feature/auth", model: "opus-4" },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.id).toBeDefined();
+      expect(result.title).toBe("CC prompt: migrate auth");
+      expect(result.artifact_type).toBe("cc-prompt");
+      expect(result.status).toBe("ready");
+      expect(result.created_at).toBeDefined();
+    });
+
+    it("creates a pointer-only artifact", async () => {
+      const result = await callTool("store_artifact", {
+        title: "Research report PDF",
+        artifact_type: "research",
+        scope: "work",
+        pointer: { type: "git", repo: "acme/research", branch: "main", path: "reports/q1.pdf" },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.id).toBeDefined();
+      expect(result.artifact_type).toBe("research");
+    });
+
+    it("defaults status to 'draft' when not provided", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Draft artifact",
+        artifact_type: "blog-post",
+        scope: "personal",
+        content: "draft body",
+      });
+      expect(created.status).toBe("draft");
+    });
+
+    it("rejects artifacts with neither content nor pointer", async () => {
+      const result = await callTool("store_artifact", {
+        title: "Missing body",
+        artifact_type: "cc-prompt",
+        scope: "work",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns validation error for empty title", async () => {
+      const result = await callTool("store_artifact", {
+        title: "",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("accepts a dependencies UUID array", async () => {
+      const a = await callTool("store_artifact", {
+        title: "A",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "first",
+      });
+      const b = await callTool("store_artifact", {
+        title: "B",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "second",
+        dependencies: [a.id],
+      });
+
+      const fetched = await callTool("get_artifact", { id: b.id });
+      expect(fetched.dependencies).toEqual([a.id]);
+    });
+  });
+
+  describe("get_artifact", () => {
+    it("retrieves full artifact by UUID", async () => {
+      const created = await callTool("store_artifact", {
+        title: "To retrieve",
+        artifact_type: "template",
+        scope: "shared",
+        content: "template body",
+        metadata: { key: "value" },
+      });
+
+      const result = await callTool("get_artifact", { id: created.id });
+      expect(result.id).toBe(created.id);
+      expect(result.content).toBe("template body");
+      expect(result.metadata).toEqual({ key: "value" });
+    });
+
+    it("returns NOT_FOUND for non-existent ID", async () => {
+      const result = await callTool("get_artifact", {
+        id: "00000000-0000-0000-0000-000000000000",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("list_artifacts", () => {
+    it("returns metadata only — not full content", async () => {
+      await callTool("store_artifact", {
+        title: "List-test artifact",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "BODY SHOULD NOT APPEAR IN LIST",
+      });
+
+      const result = await callTool("list_artifacts", {});
+      expect(result.artifacts).toBeDefined();
+      expect(result.total_count).toBeGreaterThan(0);
+      for (const a of result.artifacts) {
+        expect(a.content).toBeUndefined();
+        expect(a.id).toBeDefined();
+        expect(a.title).toBeDefined();
+        expect(a.artifact_type).toBeDefined();
+      }
+    });
+
+    it("filters by artifact_type", async () => {
+      await callTool("store_artifact", {
+        title: "type-filter cc",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "x",
+      });
+      await callTool("store_artifact", {
+        title: "type-filter blog",
+        artifact_type: "blog-post",
+        scope: "personal",
+        content: "y",
+      });
+
+      const result = await callTool("list_artifacts", { artifact_type: "blog-post" });
+      for (const a of result.artifacts) {
+        expect(a.artifact_type).toBe("blog-post");
+      }
+    });
+
+    it("filters by status", async () => {
+      await callTool("store_artifact", {
+        title: "ready-status-filter",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+        status: "ready",
+      });
+
+      const result = await callTool("list_artifacts", { status: "ready" });
+      for (const a of result.artifacts) {
+        expect(a.status).toBe("ready");
+      }
+    });
+
+    it("filters by scope", async () => {
+      await callTool("store_artifact", {
+        title: "scope-filter",
+        artifact_type: "cc-prompt",
+        scope: "shared",
+        content: "x",
+      });
+      const result = await callTool("list_artifacts", { scope: "shared" });
+      for (const a of result.artifacts) {
+        expect(a.scope).toBe("shared");
+      }
+    });
+
+    it("filters by tags with ANY-match", async () => {
+      await callTool("store_artifact", {
+        title: "tagged-artifact",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "body",
+        tags: ["unique-artifact-tag-xyz"],
+      });
+
+      const result = await callTool("list_artifacts", {
+        tags: ["unique-artifact-tag-xyz", "nonexistent"],
+      });
+      expect(result.total_count).toBeGreaterThanOrEqual(1);
+    });
+
+    it("orders by execution_order ASC when artifact_type filter is set", async () => {
+      const typeName = "order-batch-" + Date.now();
+      await callTool("store_artifact", {
+        title: "third",
+        artifact_type: typeName,
+        scope: "work",
+        content: "c",
+        execution_order: 3,
+      });
+      await callTool("store_artifact", {
+        title: "first",
+        artifact_type: typeName,
+        scope: "work",
+        content: "a",
+        execution_order: 1,
+      });
+      await callTool("store_artifact", {
+        title: "second",
+        artifact_type: typeName,
+        scope: "work",
+        content: "b",
+        execution_order: 2,
+      });
+
+      const result = await callTool("list_artifacts", { artifact_type: typeName });
+      expect(result.artifacts.length).toBe(3);
+      expect(result.artifacts[0].execution_order).toBe(1);
+      expect(result.artifacts[1].execution_order).toBe(2);
+      expect(result.artifacts[2].execution_order).toBe(3);
+    });
+
+    it("respects limit and offset", async () => {
+      const page1 = await callTool("list_artifacts", { limit: 2, offset: 0 });
+      const page2 = await callTool("list_artifacts", { limit: 2, offset: 2 });
+      expect(page1.artifacts.length).toBeLessThanOrEqual(2);
+      expect(page2.artifacts.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("search_artifacts", () => {
+    it("finds artifacts by keyword in title or content", async () => {
+      await callTool("store_artifact", {
+        title: "Unique search token qqrstt",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "body content",
+      });
+
+      const result = await callTool("search_artifacts", { query: "qqrstt" });
+      expect(result.artifacts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("includes full content in search results (unlike list)", async () => {
+      await callTool("store_artifact", {
+        title: "Search-full-content-marker-uniqueabc",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "This content SHOULD appear.",
+      });
+
+      const result = await callTool("search_artifacts", {
+        query: "uniqueabc",
+      });
+      expect(result.artifacts.length).toBeGreaterThanOrEqual(1);
+      expect(result.artifacts[0].content).toBeDefined();
+    });
+
+    it("filters by artifact_type", async () => {
+      await callTool("store_artifact", {
+        title: "Filter-type-marker-defghi",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "content",
+      });
+
+      const other = await callTool("search_artifacts", {
+        query: "defghi",
+        artifact_type: "blog-post",
+      });
+      expect(other.artifacts.length).toBe(0);
+
+      const match = await callTool("search_artifacts", {
+        query: "defghi",
+        artifact_type: "cc-prompt",
+      });
+      expect(match.artifacts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns validation error for empty query", async () => {
+      const result = await callTool("search_artifacts", { query: "" });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("update_artifact", () => {
+    it("updates basic fields", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Original title",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "Original content",
+      });
+
+      const result = await callTool("update_artifact", {
+        id: created.id,
+        title: "Updated title",
+        content: "Updated content",
+        tags: ["updated"],
+      });
+      expect(result.title).toBe("Updated title");
+      expect(result.content).toBe("Updated content");
+      expect(result.tags).toEqual(["updated"]);
+    });
+
+    it("enforces valid status transitions: draft → ready → executing → completed", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Lifecycle",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      expect(created.status).toBe("draft");
+
+      const ready = await callTool("update_artifact", { id: created.id, status: "ready" });
+      expect(ready.status).toBe("ready");
+
+      const executing = await callTool("update_artifact", { id: created.id, status: "executing" });
+      expect(executing.status).toBe("executing");
+
+      const completed = await callTool("update_artifact", { id: created.id, status: "completed" });
+      expect(completed.status).toBe("completed");
+    });
+
+    it("rejects invalid status transitions", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Bad-transition",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      // draft → completed is not allowed
+      const result = await callTool("update_artifact", { id: created.id, status: "completed" });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("INVALID_STATUS_TRANSITION");
+    });
+
+    it("allows transition to 'superseded' from any state", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Supersede-me",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      const r1 = await callTool("update_artifact", { id: created.id, status: "superseded" });
+      expect(r1.status).toBe("superseded");
+
+      const c2 = await callTool("store_artifact", {
+        title: "Supersede-from-completed",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+        status: "ready",
+      });
+      await callTool("update_artifact", { id: c2.id, status: "executing" });
+      await callTool("update_artifact", { id: c2.id, status: "completed" });
+      const r2 = await callTool("update_artifact", { id: c2.id, status: "superseded" });
+      expect(r2.status).toBe("superseded");
+    });
+
+    it("merges metadata at the top level", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Metadata-merge",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+        metadata: { a: 1, b: 2 },
+      });
+
+      const result = await callTool("update_artifact", {
+        id: created.id,
+        metadata: { b: 20, c: 3 },
+      });
+      expect(result.metadata).toEqual({ a: 1, b: 20, c: 3 });
+    });
+
+    it("returns NOT_FOUND for non-existent artifact", async () => {
+      const result = await callTool("update_artifact", {
+        id: "00000000-0000-0000-0000-000000000000",
+        title: "anything",
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("NOT_FOUND");
+    });
+
+    it("returns VALIDATION_ERROR when no updates provided", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Empty-update",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "x",
+      });
+      const result = await callTool("update_artifact", { id: created.id });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("rejects clearing both content and pointer", async () => {
+      const created = await callTool("store_artifact", {
+        title: "Clear-body",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      const result = await callTool("update_artifact", {
+        id: created.id,
+        content: null,
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("cross-tool isolation", () => {
+    it("artifacts do NOT appear in list_notes", async () => {
+      const a = await callTool("store_artifact", {
+        title: "Isolation-marker-artifact",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "should not show up in notes",
+      });
+
+      const list = await callTool("list_notes", {});
+      const found = list.notes?.some((n: any) => n.id === a.id);
+      expect(found).toBeFalsy();
+    });
+
+    it("artifacts do NOT appear in list_tasks", async () => {
+      const a = await callTool("store_artifact", {
+        title: "Isolation-marker-artifact-2",
+        artifact_type: "cc-prompt",
+        scope: "personal",
+        content: "should not show up in tasks",
+      });
+
+      const list = await callTool("list_tasks", { status: null });
+      const found = list.tasks?.some((t: any) => t.id === a.id);
+      expect(found).toBeFalsy();
+    });
+  });
+});

--- a/src/db/migrations/006_artifacts.sql
+++ b/src/db/migrations/006_artifacts.sql
@@ -1,0 +1,38 @@
+-- Artifact layer: permanent, searchable generated outputs with lifecycle state.
+-- Fourth primitive alongside handoffs (ephemeral), tasks (lifecycle), notes (knowledge).
+
+CREATE TABLE IF NOT EXISTS artifacts (
+    id                UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    title             TEXT          NOT NULL,
+    artifact_type     TEXT          NOT NULL,  -- 'cc-prompt', 'research', 'blog-post', 'template', 'presentation'
+    content           TEXT,                    -- inline content for small artifacts (prompts, short docs)
+    pointer           JSONB,                   -- {type: 'git', repo, branch, path} | {type: 'local', path} | {type: 'url', href}
+    status            TEXT          NOT NULL DEFAULT 'draft'
+                      CHECK (status IN ('draft', 'ready', 'executing', 'completed', 'superseded')),
+    scope             TEXT          NOT NULL CHECK (scope IN ('work', 'personal', 'shared')),
+    tags              TEXT[]        DEFAULT '{}',
+    dependencies      UUID[]        DEFAULT '{}',   -- other artifact IDs that must complete first
+    execution_order   INTEGER,                       -- ordering within a batch (1, 2, 3...)
+    related_task_ids  UUID[]        DEFAULT '{}',
+    metadata          JSONB         DEFAULT '{}',    -- flexible: {branch_target, model, surface, batch_label}
+    created_at        TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_type ON artifacts (artifact_type);
+CREATE INDEX IF NOT EXISTS idx_artifacts_status ON artifacts (status);
+CREATE INDEX IF NOT EXISTS idx_artifacts_scope ON artifacts (scope);
+CREATE INDEX IF NOT EXISTS idx_artifacts_tags ON artifacts USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_artifacts_created ON artifacts (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_artifacts_execution_order ON artifacts (execution_order);
+
+-- Full-text search on title + content
+CREATE INDEX IF NOT EXISTS idx_artifacts_fts ON artifacts
+    USING GIN (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')));
+
+-- Reuse update_updated_at() trigger function from 001_tasks.sql
+DROP TRIGGER IF EXISTS artifacts_updated_at ON artifacts;
+CREATE TRIGGER artifacts_updated_at
+    BEFORE UPDATE ON artifacts
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();

--- a/src/db/migrations/007_pending_embeddings_expand.sql
+++ b/src/db/migrations/007_pending_embeddings_expand.sql
@@ -1,0 +1,10 @@
+-- Expand pending_embeddings.content_type CHECK constraint to include
+-- 'note' and 'artifact' so the resilience queue can hold all indexable
+-- primitives (not just handoffs and tasks).
+
+ALTER TABLE pending_embeddings
+    DROP CONSTRAINT IF EXISTS pending_embeddings_content_type_check;
+
+ALTER TABLE pending_embeddings
+    ADD CONSTRAINT pending_embeddings_content_type_check
+    CHECK (content_type IN ('handoff', 'task', 'note', 'artifact'));

--- a/src/embeddings/indexer.ts
+++ b/src/embeddings/indexer.ts
@@ -24,7 +24,7 @@ function isTeiConnectivityError(err: unknown): boolean {
 
 /** Insert a pending embedding entry for later drain. Best-effort — tolerates missing table/DB. */
 async function enqueuePending(
-  contentType: "handoff" | "task",
+  contentType: "handoff" | "task" | "note" | "artifact",
   contentId: string
 ): Promise<void> {
   try {
@@ -132,8 +132,8 @@ async function indexTaskRaw(
   await indexContent("task", id, text, metadata);
 }
 
-/** Index a single note. */
-export async function indexNote(
+/** Raw note indexing — throws on failure. Used by drain path to avoid re-enqueueing. */
+async function indexNoteRaw(
   id: string,
   note: {
     title: string;
@@ -154,6 +154,80 @@ export async function indexNote(
     scope: note.scope ?? null,
     created_at: note.created_at ?? null,
   });
+}
+
+/** Index a single note. On TEI connectivity failure, queues for later drain. */
+export async function indexNote(
+  id: string,
+  note: {
+    title: string;
+    content: string;
+    domain?: string | null;
+    tags?: string[] | null;
+    scope?: string;
+    created_at?: string;
+  }
+): Promise<void> {
+  try {
+    await indexNoteRaw(id, note);
+  } catch (err) {
+    if (isTeiConnectivityError(err)) {
+      await enqueuePending("note", id);
+      return;
+    }
+    throw err;
+  }
+}
+
+/** Raw artifact indexing — throws on failure. Used by drain path to avoid re-enqueueing. */
+async function indexArtifactRaw(
+  id: string,
+  artifact: {
+    title: string;
+    content: string | null;
+    artifact_type: string;
+    tags?: string[] | null;
+    status?: string;
+    scope?: string;
+    created_at?: string;
+  }
+): Promise<void> {
+  const tagLine = artifact.tags?.length ? artifact.tags.join(", ") : "";
+  const parts = [artifact.title, artifact.content ?? "", artifact.artifact_type, tagLine];
+  const text = parts.filter((p) => p && p.trim()).join("\n");
+  if (!text.trim()) return;
+  await indexContent("artifact", id, text, {
+    artifact_id: id,
+    artifact_type: artifact.artifact_type,
+    tags: artifact.tags ?? [],
+    status: artifact.status ?? null,
+    scope: artifact.scope ?? null,
+    created_at: artifact.created_at ?? null,
+  });
+}
+
+/** Index a single artifact. On TEI connectivity failure, queues for later drain. */
+export async function indexArtifact(
+  id: string,
+  artifact: {
+    title: string;
+    content: string | null;
+    artifact_type: string;
+    tags?: string[] | null;
+    status?: string;
+    scope?: string;
+    created_at?: string;
+  }
+): Promise<void> {
+  try {
+    await indexArtifactRaw(id, artifact);
+  } catch (err) {
+    if (isTeiConnectivityError(err)) {
+      await enqueuePending("artifact", id);
+      return;
+    }
+    throw err;
+  }
 }
 
 /** Index a single task. On TEI connectivity failure, queues for later drain. */
@@ -292,11 +366,50 @@ export async function indexAllNotes(): Promise<number> {
   return indexed;
 }
 
+/** Bulk index all artifacts from the artifacts table. */
+export async function indexAllArtifacts(): Promise<number> {
+  const result = await query<{
+    id: string;
+    title: string;
+    content: string | null;
+    artifact_type: string;
+    tags: string[];
+    status: string;
+    scope: string;
+    created_at: string;
+  }>(
+    "SELECT id, title, content, artifact_type, tags, status, scope, created_at FROM artifacts"
+  );
+
+  let indexed = 0;
+  for (const row of result.rows) {
+    try {
+      await indexArtifact(row.id, {
+        title: row.title,
+        content: row.content,
+        artifact_type: row.artifact_type,
+        tags: row.tags,
+        status: row.status,
+        scope: row.scope,
+        created_at: row.created_at,
+      });
+      indexed++;
+    } catch (err) {
+      console.error(
+        `[indexer] Failed to index artifact ${row.id}:`,
+        (err as Error).message
+      );
+    }
+  }
+
+  return indexed;
+}
+
 // ── Pending queue drain ───────────────────────────────────────
 
 interface PendingRow {
   id: number;
-  content_type: "handoff" | "task";
+  content_type: "handoff" | "task" | "note" | "artifact";
   content_id: string;
 }
 
@@ -307,7 +420,7 @@ interface PendingRow {
  * rather than archive content whose embedding we can't confirm.
  */
 export async function hasPendingEmbedding(
-  contentType: "handoff" | "task",
+  contentType: "handoff" | "task" | "note" | "artifact",
   contentId: string
 ): Promise<boolean> {
   try {
@@ -396,7 +509,7 @@ export async function drainPendingEmbeddings(
           continue;
         }
         await indexHandoffRaw(row.content_id, handoff);
-      } else {
+      } else if (row.content_type === "task") {
         const taskResult = await query<{
           id: string;
           title: string;
@@ -428,6 +541,78 @@ export async function drainPendingEmbeddings(
           task.status,
           task.created_at
         );
+      } else if (row.content_type === "note") {
+        const noteResult = await query<{
+          id: string;
+          title: string;
+          content: string;
+          domain: string | null;
+          tags: string[];
+          scope: string;
+          created_at: string;
+        }>(
+          `SELECT id, title, content, domain, tags, scope, created_at
+           FROM notes WHERE id = $1`,
+          [row.content_id]
+        );
+        const note = noteResult.rows[0];
+        if (!note) {
+          await query(`DELETE FROM pending_embeddings WHERE id = $1`, [row.id]);
+          errors++;
+          console.warn(
+            `[indexer] Dropped pending note ${row.content_id} — source missing`
+          );
+          continue;
+        }
+        await indexNoteRaw(note.id, {
+          title: note.title,
+          content: note.content,
+          domain: note.domain,
+          tags: note.tags,
+          scope: note.scope,
+          created_at: note.created_at,
+        });
+      } else if (row.content_type === "artifact") {
+        const artifactResult = await query<{
+          id: string;
+          title: string;
+          content: string | null;
+          artifact_type: string;
+          tags: string[];
+          status: string;
+          scope: string;
+          created_at: string;
+        }>(
+          `SELECT id, title, content, artifact_type, tags, status, scope, created_at
+           FROM artifacts WHERE id = $1`,
+          [row.content_id]
+        );
+        const artifact = artifactResult.rows[0];
+        if (!artifact) {
+          await query(`DELETE FROM pending_embeddings WHERE id = $1`, [row.id]);
+          errors++;
+          console.warn(
+            `[indexer] Dropped pending artifact ${row.content_id} — source missing`
+          );
+          continue;
+        }
+        await indexArtifactRaw(artifact.id, {
+          title: artifact.title,
+          content: artifact.content,
+          artifact_type: artifact.artifact_type,
+          tags: artifact.tags,
+          status: artifact.status,
+          scope: artifact.scope,
+          created_at: artifact.created_at,
+        });
+      } else {
+        // Unknown content_type — drop and move on so the queue can drain.
+        await query(`DELETE FROM pending_embeddings WHERE id = $1`, [row.id]);
+        errors++;
+        console.warn(
+          `[indexer] Dropped pending ${row.content_type} ${row.content_id} — unsupported content_type`
+        );
+        continue;
       }
 
       await query(`DELETE FROM pending_embeddings WHERE id = $1`, [row.id]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { registerHandoffTools } from "./tools/handoff.js";
 import { registerHandoffNavTools } from "./tools/handoff-nav.js";
 import { registerTaskTools } from "./tools/tasks.js";
 import { registerNoteTools } from "./tools/notes.js";
+import { registerArtifactTools } from "./tools/artifacts.js";
 import { registerSearchTools } from "./tools/search.js";
 import { ensureDataDir } from "./storage/json-store.js";
 import { runMigrations } from "./db/migrate.js";
@@ -84,6 +85,7 @@ function createMcpServer(): McpServer {
   registerHandoffNavTools(server);
   registerTaskTools(server);
   registerNoteTools(server);
+  registerArtifactTools(server);
   registerSearchTools(server);
   return server;
 }

--- a/src/tools/artifacts.ts
+++ b/src/tools/artifacts.ts
@@ -1,0 +1,530 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { query } from "../db/client.js";
+import { indexArtifact } from "../embeddings/indexer.js";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface ArtifactRow {
+  id: string;
+  title: string;
+  artifact_type: string;
+  content: string | null;
+  pointer: Record<string, unknown> | null;
+  status: string;
+  scope: string;
+  tags: string[];
+  dependencies: string[];
+  execution_order: number | null;
+  related_task_ids: string[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+function formatArtifact(row: ArtifactRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    artifact_type: row.artifact_type,
+    content: row.content,
+    pointer: row.pointer,
+    status: row.status,
+    scope: row.scope,
+    tags: row.tags || [],
+    dependencies: row.dependencies || [],
+    execution_order: row.execution_order,
+    related_task_ids: row.related_task_ids || [],
+    metadata: row.metadata || {},
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function formatArtifactListItem(row: ArtifactRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    artifact_type: row.artifact_type,
+    status: row.status,
+    scope: row.scope,
+    tags: row.tags || [],
+    execution_order: row.execution_order,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function jsonResponse(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
+
+function errorResponse(message: string, code: string) {
+  return jsonResponse({ error: true, message, code });
+}
+
+// Allowed status transitions — graph check against the DB CHECK constraint.
+// Any state may move to 'superseded' (tombstone-style retirement).
+const STATUS_TRANSITIONS: Record<string, string[]> = {
+  draft: ["ready", "superseded"],
+  ready: ["executing", "draft", "superseded"],
+  executing: ["completed", "ready", "superseded"],
+  completed: ["superseded"],
+  superseded: [],
+};
+
+function isValidStatusTransition(from: string, to: string): boolean {
+  if (from === to) return true;
+  const allowed = STATUS_TRANSITIONS[from];
+  return Boolean(allowed && allowed.includes(to));
+}
+
+// ── Zod Schemas ──────────────────────────────────────────────────
+
+const scopeEnum = z.enum(["work", "personal", "shared"]);
+const statusEnum = z.enum(["draft", "ready", "executing", "completed", "superseded"]);
+const listOrderByEnum = z.enum(["created_at", "updated_at", "execution_order"]);
+const orderDirEnum = z.enum(["asc", "desc"]);
+
+const pointerSchema = z.object({
+  type: z.string().describe("Pointer type: 'git', 'local', 'url', or any deployment-specific scheme"),
+}).passthrough();
+
+// ── Tool Descriptions ────────────────────────────────────────────
+
+const STORE_ARTIFACT_DESC = `Store a generated output as an artifact. Artifacts are the fourth content primitive — tracked, searchable, lifecycle-aware outputs that bridge planning and execution. Use for Claude Code prompts, research reports, blog posts, templates, presentations — anything generated once and consumed later.
+
+How artifacts differ from the other primitives:
+- Tasks are action items with an open/completed lifecycle — "write the migration" is a task.
+- Notes are permanent interpretation — decisions, patterns, takeaways. No lifecycle, no ordering.
+- Handoffs are ephemeral session state.
+- Artifacts are the concrete outputs produced by work. They have a status lifecycle (draft → ready → executing → completed) and can be ordered within a batch via execution_order.
+
+Storage modes:
+- Inline 'content' — for small artifacts like CC prompts, snippets, short docs. Stored directly in Postgres, indexed for semantic search.
+- 'pointer' — for large artifacts (binaries, generated media, repo files). Stored externally; the pointer describes how to fetch it. Shape: {type: 'git', repo, branch, path} | {type: 'local', path} | {type: 'url', href}.
+- You may provide both when content is a preview/summary and the pointer is the canonical source.
+
+Status lifecycle:
+- draft — being assembled, not ready for use
+- ready — finalized and available for execution or consumption
+- executing — currently being acted on (e.g., a CC prompt being run)
+- completed — execution finished
+- superseded — replaced or retired; reachable from any state
+
+Use 'execution_order' to sequence artifacts within a batch (e.g., a chain of CC prompts where 1 builds infrastructure, 2 adds tests, 3 updates docs). Use 'dependencies' for explicit cross-artifact ordering when execution_order is not enough. Use 'metadata' for flexible fields like branch_target, model, surface, batch_label.
+
+Returns {id, title, artifact_type, status, created_at}. Re-embeds on create; falls back to the pending queue if the embedding server is offline.`;
+
+const GET_ARTIFACT_DESC = `Retrieve a single artifact by its UUID. Returns the full artifact record including content, pointer, dependencies, and metadata.`;
+
+const LIST_ARTIFACTS_DESC = `List artifacts with optional filters and pagination. Returns metadata only (id, title, artifact_type, status, scope, tags, execution_order, timestamps) — NOT the full content. Call get_artifact to retrieve a body.
+
+This is the primary retrieval tool for execution sessions. Calling list_artifacts({artifact_type: 'cc-prompt', status: 'ready'}) returns the next ordered batch of prompts ready to run. Defaults to execution_order ASC when filtering by artifact_type, otherwise created_at DESC.
+
+Filters (all optional):
+- artifact_type — e.g., 'cc-prompt', 'research', 'blog-post'
+- status — 'draft' | 'ready' | 'executing' | 'completed' | 'superseded'
+- scope — 'work' | 'personal' | 'shared'
+- tags — ANY-match array`;
+
+const UPDATE_ARTIFACT_DESC = `Update fields on an existing artifact. All fields are optional — only provided fields are modified. Tags, dependencies, and related_task_ids are full-replacement (provide complete arrays). Metadata merges at the top level (provided keys overwrite; omitted keys are preserved).
+
+Status transitions are enforced:
+- draft → ready, superseded
+- ready → executing, draft, superseded
+- executing → completed, ready, superseded
+- completed → superseded
+- Any state → superseded (retirement)
+
+Re-embeds when title, content, tags, or artifact_type change.`;
+
+const SEARCH_ARTIFACTS_DESC = `Full-text search across artifact titles and content using PostgreSQL FTS with English stemming. Returns matching artifacts WITH full content (unlike list_artifacts), ranked by relevance.
+
+For cross-type semantic search that finds artifacts alongside handoffs, tasks, and notes, use search_context with content_types: ['artifact'] instead — this tool only searches within the artifacts table.
+
+Filters: artifact_type, status, scope.`;
+
+// ── Tool Registration ────────────────────────────────────────────
+
+export function registerArtifactTools(mcpServer: McpServer): void {
+  // ── store_artifact ───────────────────────────────────────────
+  mcpServer.tool(
+    "store_artifact",
+    STORE_ARTIFACT_DESC,
+    {
+      title: z.string().describe("Short descriptive title for the artifact"),
+      artifact_type: z.string().describe("Kind of artifact, e.g., 'cc-prompt', 'research', 'blog-post', 'template', 'presentation'. Free-form — new types are valid."),
+      scope: scopeEnum.describe("'work', 'personal', or 'shared'"),
+      content: z.string().optional().describe("Inline artifact body. Required if pointer is not provided."),
+      pointer: pointerSchema.optional().describe("External storage pointer: {type: 'git', repo, branch, path} | {type: 'local', path} | {type: 'url', href}. Required if content is not provided."),
+      status: statusEnum.optional().describe("Lifecycle state (default 'draft')"),
+      tags: z.array(z.string()).optional().describe("Free-form tags"),
+      dependencies: z.array(z.string()).optional().describe("UUIDs of artifacts that must complete before this one"),
+      execution_order: z.number().int().optional().describe("Ordering within a batch (1, 2, 3...). Use for sequenced prompt chains."),
+      related_task_ids: z.array(z.string()).optional().describe("UUIDs of tasks this artifact relates to"),
+      metadata: z.record(z.unknown()).optional().describe("Flexible metadata: branch_target, model, surface, batch_label, etc."),
+    },
+    async (args) => {
+      if (!args.title?.trim()) {
+        return errorResponse("title is required", "VALIDATION_ERROR");
+      }
+      if (!args.artifact_type?.trim()) {
+        return errorResponse("artifact_type is required", "VALIDATION_ERROR");
+      }
+      const hasContent = typeof args.content === "string" && args.content.trim().length > 0;
+      const hasPointer = args.pointer && typeof args.pointer === "object";
+      if (!hasContent && !hasPointer) {
+        return errorResponse(
+          "Artifact must have either 'content' or 'pointer' (or both)",
+          "VALIDATION_ERROR"
+        );
+      }
+
+      try {
+        const result = await query<ArtifactRow>(
+          `INSERT INTO artifacts (
+             title, artifact_type, content, pointer, status, scope,
+             tags, dependencies, execution_order, related_task_ids, metadata
+           )
+           VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8::uuid[], $9, $10::uuid[], $11::jsonb)
+           RETURNING *`,
+          [
+            args.title,
+            args.artifact_type,
+            args.content ?? null,
+            args.pointer ? JSON.stringify(args.pointer) : null,
+            args.status ?? "draft",
+            args.scope,
+            args.tags ?? [],
+            args.dependencies ?? [],
+            args.execution_order ?? null,
+            args.related_task_ids ?? [],
+            JSON.stringify(args.metadata ?? {}),
+          ]
+        );
+        const row = result.rows[0];
+        indexArtifact(row.id, {
+          title: row.title,
+          content: row.content,
+          artifact_type: row.artifact_type,
+          tags: row.tags,
+          status: row.status,
+          scope: row.scope,
+          created_at: row.created_at,
+        }).catch((err) =>
+          console.warn("[store_artifact] Background indexing failed:", err.message)
+        );
+        return jsonResponse({
+          id: row.id,
+          title: row.title,
+          artifact_type: row.artifact_type,
+          status: row.status,
+          created_at: row.created_at,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── get_artifact ─────────────────────────────────────────────
+  mcpServer.tool(
+    "get_artifact",
+    GET_ARTIFACT_DESC,
+    {
+      id: z.string().describe("UUID of the artifact to retrieve"),
+    },
+    async (args) => {
+      try {
+        const result = await query<ArtifactRow>(
+          "SELECT * FROM artifacts WHERE id = $1",
+          [args.id]
+        );
+        if (result.rows.length === 0) {
+          return errorResponse(`Artifact not found: ${args.id}`, "NOT_FOUND");
+        }
+        return jsonResponse(formatArtifact(result.rows[0]));
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── list_artifacts ───────────────────────────────────────────
+  mcpServer.tool(
+    "list_artifacts",
+    LIST_ARTIFACTS_DESC,
+    {
+      artifact_type: z.string().optional().describe("Filter by artifact_type"),
+      status: statusEnum.optional().describe("Filter by status"),
+      scope: scopeEnum.nullable().optional().describe("Filter by scope"),
+      tags: z.array(z.string()).optional().describe("Filter by tags (ANY match)"),
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 20)"),
+      offset: z.number().min(0).optional().describe("Offset for pagination (default 0)"),
+      order_by: listOrderByEnum.optional().describe("Sort field. Default: 'execution_order' when artifact_type filter is set, otherwise 'created_at'"),
+      order_dir: orderDirEnum.optional().describe("Sort direction. Default: 'asc' for execution_order, 'desc' for created_at/updated_at"),
+    },
+    async (args) => {
+      try {
+        const conditions: string[] = [];
+        const params: unknown[] = [];
+        let paramIdx = 1;
+
+        if (args.artifact_type) {
+          conditions.push(`artifact_type = $${paramIdx++}`);
+          params.push(args.artifact_type);
+        }
+        if (args.status) {
+          conditions.push(`status = $${paramIdx++}`);
+          params.push(args.status);
+        }
+        if (args.scope) {
+          conditions.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+        if (args.tags && args.tags.length > 0) {
+          conditions.push(`tags && $${paramIdx++}`);
+          params.push(args.tags);
+        }
+
+        const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+        const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+        const offset = Math.max(args.offset ?? 0, 0);
+
+        const typeFiltered = Boolean(args.artifact_type);
+        const orderBy = args.order_by ?? (typeFiltered ? "execution_order" : "created_at");
+        const defaultDir = orderBy === "execution_order" ? "asc" : "desc";
+        const orderDir = (args.order_dir ?? defaultDir).toUpperCase();
+        const orderClause = `ORDER BY ${orderBy} ${orderDir} NULLS LAST`;
+
+        const countResult = await query<{ count: string }>(
+          `SELECT COUNT(*) as count FROM artifacts ${where}`,
+          params
+        );
+        const totalCount = parseInt(countResult.rows[0].count, 10);
+
+        const dataResult = await query<ArtifactRow>(
+          `SELECT * FROM artifacts ${where} ${orderClause} LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+          [...params, limit, offset]
+        );
+
+        return jsonResponse({
+          artifacts: dataResult.rows.map(formatArtifactListItem),
+          total_count: totalCount,
+          limit,
+          offset,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── search_artifacts ─────────────────────────────────────────
+  mcpServer.tool(
+    "search_artifacts",
+    SEARCH_ARTIFACTS_DESC,
+    {
+      query: z.string().describe("Full-text search query"),
+      artifact_type: z.string().optional().describe("Filter by artifact_type"),
+      status: statusEnum.optional().describe("Filter by status"),
+      scope: scopeEnum.nullable().optional().describe("Filter by scope"),
+      limit: z.number().min(1).max(50).optional().describe("Max results (1-50, default 10)"),
+    },
+    async (args) => {
+      if (!args.query?.trim()) {
+        return errorResponse("query is required", "VALIDATION_ERROR");
+      }
+
+      try {
+        const conditions: string[] = [
+          `to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')) @@ plainto_tsquery('english', $1)`,
+        ];
+        const params: unknown[] = [args.query];
+        let paramIdx = 2;
+
+        if (args.artifact_type) {
+          conditions.push(`artifact_type = $${paramIdx++}`);
+          params.push(args.artifact_type);
+        }
+        if (args.status) {
+          conditions.push(`status = $${paramIdx++}`);
+          params.push(args.status);
+        }
+        if (args.scope) {
+          conditions.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+
+        const limit = Math.min(Math.max(args.limit ?? 10, 1), 50);
+        const where = conditions.join(" AND ");
+
+        const countResult = await query<{ count: string }>(
+          `SELECT COUNT(*) as count FROM artifacts WHERE ${where}`,
+          params
+        );
+        const totalCount = parseInt(countResult.rows[0].count, 10);
+
+        const dataResult = await query<ArtifactRow & { rank: number }>(
+          `SELECT *, ts_rank(
+            to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')),
+            plainto_tsquery('english', $1)
+          ) AS rank
+          FROM artifacts WHERE ${where}
+          ORDER BY rank DESC
+          LIMIT $${paramIdx}`,
+          [...params, limit]
+        );
+
+        return jsonResponse({
+          artifacts: dataResult.rows.map((row) => ({
+            ...formatArtifact(row),
+            rank: row.rank,
+          })),
+          total_count: totalCount,
+        });
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+
+  // ── update_artifact ──────────────────────────────────────────
+  mcpServer.tool(
+    "update_artifact",
+    UPDATE_ARTIFACT_DESC,
+    {
+      id: z.string().describe("UUID of the artifact to update"),
+      title: z.string().optional().describe("New title"),
+      artifact_type: z.string().optional().describe("New artifact_type"),
+      content: z.string().nullable().optional().describe("New inline content, or null to clear"),
+      pointer: pointerSchema.nullable().optional().describe("New pointer, or null to clear"),
+      status: statusEnum.optional().describe("New status — must follow valid transitions"),
+      scope: scopeEnum.optional().describe("New scope"),
+      tags: z.array(z.string()).optional().describe("New tags (full replacement)"),
+      dependencies: z.array(z.string()).optional().describe("New dependencies (full replacement)"),
+      execution_order: z.number().int().nullable().optional().describe("New execution_order, or null to clear"),
+      related_task_ids: z.array(z.string()).optional().describe("New related task IDs (full replacement)"),
+      metadata: z.record(z.unknown()).optional().describe("Metadata to merge (top-level keys)"),
+    },
+    async (args) => {
+      try {
+        const existing = await query<ArtifactRow>(
+          "SELECT * FROM artifacts WHERE id = $1",
+          [args.id]
+        );
+        if (existing.rows.length === 0) {
+          return errorResponse(`Artifact not found: ${args.id}`, "NOT_FOUND");
+        }
+        const current = existing.rows[0];
+
+        if (args.status !== undefined && !isValidStatusTransition(current.status, args.status)) {
+          return errorResponse(
+            `Invalid status transition: ${current.status} → ${args.status}`,
+            "INVALID_STATUS_TRANSITION"
+          );
+        }
+
+        // Ensure post-update we still have content or pointer.
+        const nextContent =
+          args.content !== undefined ? args.content : current.content;
+        const nextPointer =
+          args.pointer !== undefined ? args.pointer : current.pointer;
+        const hasContent = typeof nextContent === "string" && nextContent.trim().length > 0;
+        const hasPointer = nextPointer && typeof nextPointer === "object";
+        if (!hasContent && !hasPointer) {
+          return errorResponse(
+            "Artifact must retain either 'content' or 'pointer' after update",
+            "VALIDATION_ERROR"
+          );
+        }
+
+        const sets: string[] = [];
+        const params: unknown[] = [];
+        let paramIdx = 1;
+
+        if (args.title !== undefined) {
+          sets.push(`title = $${paramIdx++}`);
+          params.push(args.title);
+        }
+        if (args.artifact_type !== undefined) {
+          sets.push(`artifact_type = $${paramIdx++}`);
+          params.push(args.artifact_type);
+        }
+        if (args.content !== undefined) {
+          sets.push(`content = $${paramIdx++}`);
+          params.push(args.content);
+        }
+        if (args.pointer !== undefined) {
+          sets.push(`pointer = $${paramIdx++}::jsonb`);
+          params.push(args.pointer ? JSON.stringify(args.pointer) : null);
+        }
+        if (args.status !== undefined) {
+          sets.push(`status = $${paramIdx++}`);
+          params.push(args.status);
+        }
+        if (args.scope !== undefined) {
+          sets.push(`scope = $${paramIdx++}`);
+          params.push(args.scope);
+        }
+        if (args.tags !== undefined) {
+          sets.push(`tags = $${paramIdx++}`);
+          params.push(args.tags);
+        }
+        if (args.dependencies !== undefined) {
+          sets.push(`dependencies = $${paramIdx++}::uuid[]`);
+          params.push(args.dependencies);
+        }
+        if (args.execution_order !== undefined) {
+          sets.push(`execution_order = $${paramIdx++}`);
+          params.push(args.execution_order);
+        }
+        if (args.related_task_ids !== undefined) {
+          sets.push(`related_task_ids = $${paramIdx++}::uuid[]`);
+          params.push(args.related_task_ids);
+        }
+        if (args.metadata !== undefined) {
+          // Top-level merge — provided keys overwrite, existing preserved.
+          sets.push(`metadata = metadata || $${paramIdx++}::jsonb`);
+          params.push(JSON.stringify(args.metadata));
+        }
+
+        if (sets.length === 0) {
+          return errorResponse("No updates provided", "VALIDATION_ERROR");
+        }
+
+        const result = await query<ArtifactRow>(
+          `UPDATE artifacts SET ${sets.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
+          [...params, args.id]
+        );
+        const row = result.rows[0];
+
+        const contentChanged =
+          args.title !== undefined ||
+          args.content !== undefined ||
+          args.tags !== undefined ||
+          args.artifact_type !== undefined;
+        if (contentChanged) {
+          indexArtifact(row.id, {
+            title: row.title,
+            content: row.content,
+            artifact_type: row.artifact_type,
+            tags: row.tags,
+            status: row.status,
+            scope: row.scope,
+            created_at: row.created_at,
+          }).catch((err) =>
+            console.warn("[update_artifact] Background indexing failed:", err.message)
+          );
+        }
+
+        return jsonResponse(formatArtifact(row));
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
+    }
+  );
+}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -4,7 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { config } from "../config.js";
 import { query } from "../db/client.js";
 import { generateEmbedding, isEmbeddingAvailable, rerankResults } from "../embeddings/client.js";
-import { indexAllHandoffs, indexAllTasks, indexAllNotes, drainPendingEmbeddings } from "../embeddings/indexer.js";
+import { indexAllHandoffs, indexAllTasks, indexAllNotes, indexAllArtifacts, drainPendingEmbeddings } from "../embeddings/indexer.js";
 import { lookupEntities, computeEnvelope, emptyEnvelope, generateBoundaryNotice } from "./entities.js";
 import { expandQuery } from "./search-aliases.js";
 
@@ -73,7 +73,7 @@ export function deduplicateResults(rows: SearchResultRow[]): { deduped: SearchRe
   return { deduped, preDedupCount };
 }
 
-const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content — handoffs, tasks, documents. Results ranked by meaning similarity.
+const SEARCH_CONTEXT_DESCRIPTION = `Semantic search across indexed content — handoffs, tasks, notes, artifacts, documents. Results ranked by meaning similarity.
 
 WHEN TO SEARCH: Proactively before responding about named people, hardware/devices, career/comp, network infra, medical, financial context, or continuity cues ("last time", "we discussed").
 
@@ -93,14 +93,14 @@ Response Format:
 - Reasoning-capable models (Claude Opus, o1, Gemini with thinking): Use structured reflection before synthesizing results. Evaluate whether retrieved evidence actually supports the user's question. Note gaps explicitly when results are thin or off-topic.
 - Standard models (Claude Sonnet/Haiku, GPT-4.x, Gemini Flash): Respond directly using available results. Flag when results seem insufficient and suggest query reformulation.`;
 
-const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs, tasks, and notes. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
+const REINDEX_DESCRIPTION = `Rebuild the semantic search index by re-embedding all handoffs, tasks, notes, and artifacts. Use after bulk data changes, bulk imports, or when search_context results seem stale or incomplete.
 
 WARNING: Can take several minutes for large datasets (1000+ handoffs). Re-embeds all content, not just changed items. Inform the user of expected duration before running.
 
 Parameters:
-  - content_types (optional): Which to reindex. Default: all. Options: 'handoff', 'task', 'note'
+  - content_types (optional): Which to reindex. Default: all. Options: 'handoff', 'task', 'note', 'artifact'
 
-Returns: {handoffs: {indexed, skipped, errors}, tasks: {indexed}, notes: {indexed}}`;
+Returns: {handoffs: {indexed, skipped, errors}, tasks: {indexed}, notes: {indexed}, artifacts: {indexed}}`;
 
 export function registerSearchTools(mcpServer: McpServer): void {
   // \u2500\u2500 search_context \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -110,7 +110,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
     {
       query: z.string().describe("Natural language search query"),
       content_types: z
-        .array(z.enum(["handoff", "task", "note", "document", "transcript"]))
+        .array(z.enum(["handoff", "task", "note", "artifact", "document", "transcript"]))
         .optional()
         .describe("Filter by content type. Default: search all."),
       limit: z
@@ -400,7 +400,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
     REINDEX_DESCRIPTION,
     {
       content_types: z
-        .array(z.enum(["handoff", "task", "note"]))
+        .array(z.enum(["handoff", "task", "note", "artifact"]))
         .optional()
         .describe("Which types to reindex. Default: all."),
     },
@@ -419,7 +419,7 @@ export function registerSearchTools(mcpServer: McpServer): void {
         };
       }
 
-      const types = args.content_types ?? ["handoff", "task", "note"];
+      const types = args.content_types ?? ["handoff", "task", "note", "artifact"];
       const results: Record<string, unknown> = {};
 
       // Drain pending queue first so recovered items aren't re-processed by the full reindex below.
@@ -438,6 +438,11 @@ export function registerSearchTools(mcpServer: McpServer): void {
       if (types.includes("note")) {
         const count = await indexAllNotes();
         results.notes = { indexed: count };
+      }
+
+      if (types.includes("artifact")) {
+        const count = await indexAllArtifacts();
+        results.artifacts = { indexed: count };
       }
 
       return {


### PR DESCRIPTION
## Summary

- **Artifact layer** (fourth primitive): `artifacts` table + 5 MCP tools (`store_artifact`, `get_artifact`, `list_artifacts`, `search_artifacts`, `update_artifact`) with enforced status lifecycle (draft → ready → executing → completed → superseded), `execution_order` for sequenced prompt chains, and inline-content-or-pointer storage. `'artifact'` wired into `search_context` and `reindex`.
- **Embedding resilience (bug #37):** `indexNote` and `indexArtifact` now use the same TEI-connectivity → pending-queue fallback as `indexHandoff`/`indexTask`. `drainPendingEmbeddings` handles all four content types. Migration 007 expands the `pending_embeddings` CHECK constraint.
- **Tooling hygiene:** `mergeEntities` extracted to `scripts/merge-entities.ts` so its tests no longer require the `@anthropic-ai/sdk` devDependency to load (previously blocked test collection).
- **Version bump:** `0.5.4` → `0.7.0`. ROADMAP restructured so v0.5.4 / v0.6 move to Completed, v0.7.0 becomes Current, Primitive Evolution pushed to v0.8.

Closes #27
Closes #37

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm test` without Postgres: 155 passed, 92 skipped, 0 failures
- [x] `npm test` with Postgres (pgvector/pgvector:pg16): **247 passed, 0 skipped, 0 failures**
- [x] Migrations 006 + 007 apply cleanly on a fresh database
- [x] `list_artifacts({artifact_type, status: 'ready'})` returns execution_order-sorted results
- [x] Status-transition enforcement rejects invalid jumps (e.g., draft → completed)
- [x] Any-state → superseded allowed
- [x] `search_context(content_types: ['artifact'])` returns artifact rows after reindex
- [x] `drainPendingEmbeddings` processes queued note + artifact items
- [x] PII audit: all new fixtures use generic placeholders (`acme`, opaque tokens); no real names/domains/device IDs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)