### PR TITLE
feat: v0.7.1 — artifact integrity (execution_order uniqueness + dependencies validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Both return JSON. Use `/health` for uptime monitoring and `/health/ready` after 
 
 ```bash
 curl http://localhost:3100/health
-# {"status":"ok","version":"0.7.0","uptime":42}
+# {"status":"ok","version":"0.7.1","uptime":42}
 
 curl http://localhost:3100/health/ready
 # {"status":"ok","archive":true,"uptime":42}
@@ -253,7 +253,7 @@ After connecting, ask your AI assistant to call `get_latest_handoff`. If it retu
 
 ```bash
 curl http://localhost:3100/health
-# {"status":"ok","version":"0.7.0","uptime":42}
+# {"status":"ok","version":"0.7.1","uptime":42}
 ```
 
 ## External Access with Auth Proxy
@@ -323,8 +323,8 @@ Insecure images never reach the registry — Snyk gates the push. By the time a 
 **To cut a release:**
 
 ```bash
-git tag v0.7.0
-git push origin v0.7.0
+git tag v0.7.1
+git push origin v0.7.1
 ```
 
 Old SHA-tagged images are pruned weekly (90-day retention), preserving any image referenced by a release tag.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,19 +64,26 @@ All four primitives share a unified semantic search index (pgvector + FTS with R
 - **Automated handoff compaction:** Session-boundary pruning with vector archival — keeps handoffs small, history searchable
 - **Schema hygiene:** `schema_version` field on handoffs for forward/backward compatibility
 
-## Current: v0.7.0 — Artifact Layer & Embedding Resilience Fix
-
-Focus: introduce the fourth primitive and close the last gap in pending-queue resilience.
+### v0.7.0 — Artifact Layer & Embedding Resilience Fix
 
 - **Artifact layer (fourth primitive):** `artifacts` table in PostgreSQL with MCP tools (`store_artifact`, `get_artifact`, `list_artifacts`, `search_artifacts`, `update_artifact`); lifecycle state (draft → ready → executing → completed → superseded) with enforced transitions; `execution_order` for sequenced prompt chains; inline content or external pointer (git/local/url); `'artifact'` added to `search_context` and `reindex` `content_types`
 - **Embedding resilience (bug fix #37):** `indexNote` and `indexArtifact` now use the same TEI-connectivity → pending-queue fallback as `indexHandoff`/`indexTask`; `drainPendingEmbeddings` handles all four content types; `pending_embeddings` CHECK constraint expanded in migration `007`
 - **Tooling hygiene:** `mergeEntities` split out of `scripts/extract-entities.ts` into `scripts/merge-entities.ts` so its tests no longer require the `@anthropic-ai/sdk` devDependency to load
+
+## Current: v0.7.1 — Artifact Integrity Fixes
+
+Follow-up fixes surfaced during PR #39 review.
+
+- **execution_order uniqueness (closes #40):** Partial unique index on `(artifact_type, execution_order)` where `execution_order IS NOT NULL`. `store_artifact` and `update_artifact` surface the conflict as `EXECUTION_ORDER_CONFLICT` instead of a raw `DB_ERROR`. Null slots remain unconstrained so existing v0.7.0 rows keep working.
+- **dependencies validation (closes #44):** Write-time existence check on `dependencies` UUIDs in both `store_artifact` and `update_artifact`. Non-existent references return `VALIDATION_ERROR`; malformed UUIDs are caught before the database cast. Adds a GIN index on `dependencies` for efficient reverse-lookup queries. Full referential integrity (junction table with FKs) deferred to v0.8.
+- Migration `008_artifact_integrity.sql` combines both index additions; idempotent and safe on top of v0.7.0 data.
 
 ## Future: v0.8 — Primitive Evolution
 
 Focus: deepen the four primitives with richer structure and cross-primitive linking.
 
 - **Artifact versioning & hashing:** SHA-256 content hashing and version chains for artifacts (supersedes relationships beyond the flat `superseded` status)
+- **Artifact dependency referential integrity:** Junction table with foreign keys to replace the `dependencies UUID[]` column, giving true FK enforcement and cascade behavior on delete (v0.7.1 adds write-time validation as an interim fix)
 - **Task schema evolution:** Subtasks (parent_id), relations (blocks/blocked-by/related), custom fields (JSONB UDAs); hierarchy is opt-in, flat tasks remain the default
 - **Bitemporal entity constraints:** `valid_from`/`valid_until` on entities to prevent stale constraint application
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-library",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-library",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@hono/mcp": "^0.2.4",
         "@hono/node-server": "^1.19.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-library",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/__tests__/artifacts.test.ts
+++ b/src/__tests__/artifacts.test.ts
@@ -619,4 +619,150 @@ describe.skipIf(!pgAvailable)("Artifact Tools", () => {
       expect(found).toBeFalsy();
     });
   });
+
+  describe("execution_order uniqueness", () => {
+    it("rejects duplicate execution_order within the same artifact_type", async () => {
+      const typeName = "dup-order-" + Date.now();
+      await callTool("store_artifact", {
+        title: "first",
+        artifact_type: typeName,
+        scope: "work",
+        content: "a",
+        execution_order: 1,
+      });
+      const dup = await callTool("store_artifact", {
+        title: "second",
+        artifact_type: typeName,
+        scope: "work",
+        content: "b",
+        execution_order: 1,
+      });
+      expect(dup.error).toBe(true);
+      expect(dup.code).toBe("EXECUTION_ORDER_CONFLICT");
+      expect(dup.message).toContain(typeName);
+    });
+
+    it("allows the same execution_order across different artifact_types", async () => {
+      const stamp = Date.now();
+      const typeA = "type-a-" + stamp;
+      const typeB = "type-b-" + stamp;
+      const a = await callTool("store_artifact", {
+        title: "a1",
+        artifact_type: typeA,
+        scope: "work",
+        content: "a",
+        execution_order: 1,
+      });
+      const b = await callTool("store_artifact", {
+        title: "b1",
+        artifact_type: typeB,
+        scope: "work",
+        content: "b",
+        execution_order: 1,
+      });
+      expect(a.error).toBeUndefined();
+      expect(b.error).toBeUndefined();
+    });
+
+    it("allows multiple artifacts with null execution_order in the same type", async () => {
+      const typeName = "null-order-" + Date.now();
+      const a = await callTool("store_artifact", {
+        title: "a",
+        artifact_type: typeName,
+        scope: "work",
+        content: "a",
+      });
+      const b = await callTool("store_artifact", {
+        title: "b",
+        artifact_type: typeName,
+        scope: "work",
+        content: "b",
+      });
+      expect(a.error).toBeUndefined();
+      expect(b.error).toBeUndefined();
+    });
+
+    it("update_artifact rejects moving to a duplicate execution_order", async () => {
+      const typeName = "update-dup-" + Date.now();
+      await callTool("store_artifact", {
+        title: "a",
+        artifact_type: typeName,
+        scope: "work",
+        content: "a",
+        execution_order: 1,
+      });
+      const b = await callTool("store_artifact", {
+        title: "b",
+        artifact_type: typeName,
+        scope: "work",
+        content: "b",
+        execution_order: 2,
+      });
+      const result = await callTool("update_artifact", { id: b.id, execution_order: 1 });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("EXECUTION_ORDER_CONFLICT");
+      expect(result.message).toContain(typeName);
+    });
+  });
+
+  describe("dependencies validation", () => {
+    it("rejects store_artifact with non-existent dependency UUID", async () => {
+      const result = await callTool("store_artifact", {
+        title: "bad-dep",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+        dependencies: ["00000000-0000-0000-0000-000000000000"],
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+      expect(result.message).toContain("00000000-0000-0000-0000-000000000000");
+    });
+
+    it("rejects update_artifact adding a non-existent dependency UUID", async () => {
+      const a = await callTool("store_artifact", {
+        title: "a",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      const result = await callTool("update_artifact", {
+        id: a.id,
+        dependencies: ["00000000-0000-0000-0000-000000000000"],
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("accepts update_artifact clearing dependencies with an empty array", async () => {
+      const a = await callTool("store_artifact", {
+        title: "a",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+      });
+      const b = await callTool("store_artifact", {
+        title: "b",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "y",
+        dependencies: [a.id],
+      });
+      const cleared = await callTool("update_artifact", { id: b.id, dependencies: [] });
+      expect(cleared.error).toBeUndefined();
+      expect(cleared.dependencies).toEqual([]);
+    });
+
+    it("rejects malformed UUID in dependencies", async () => {
+      const result = await callTool("store_artifact", {
+        title: "bad-uuid",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "x",
+        dependencies: ["not-a-uuid"],
+      });
+      expect(result.error).toBe(true);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+  });
 });

--- a/src/__tests__/artifacts.test.ts
+++ b/src/__tests__/artifacts.test.ts
@@ -734,6 +734,42 @@ describe.skipIf(!pgAvailable)("Artifact Tools", () => {
       expect(result.code).toBe("VALIDATION_ERROR");
     });
 
+    it("accepts uppercase/mixed-case UUID in dependencies", async () => {
+      // Postgres uuid type is case-insensitive and returns canonical lowercase.
+      // Regression: validateDependenciesExist must compare case-insensitively
+      // so an uppercase input (still a valid UUID) is not falsely reported
+      // as missing.
+      const a = await callTool("store_artifact", {
+        title: "dep-target",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "target",
+      });
+      const upper = (a.id as string).toUpperCase();
+      const b = await callTool("store_artifact", {
+        title: "dep-consumer",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "consumer",
+        dependencies: [upper],
+      });
+      expect(b.error).toBeUndefined();
+      expect(b.id).toBeDefined();
+
+      // Same check on update_artifact.
+      const c = await callTool("store_artifact", {
+        title: "dep-updater",
+        artifact_type: "cc-prompt",
+        scope: "work",
+        content: "updater",
+      });
+      const updated = await callTool("update_artifact", {
+        id: c.id,
+        dependencies: [upper],
+      });
+      expect(updated.error).toBeUndefined();
+    });
+
     it("accepts update_artifact clearing dependencies with an empty array", async () => {
       const a = await callTool("store_artifact", {
         title: "a",

--- a/src/db/migrations/008_artifact_integrity.sql
+++ b/src/db/migrations/008_artifact_integrity.sql
@@ -1,0 +1,18 @@
+-- Artifact integrity follow-ups to the v0.7.0 artifact layer.
+--
+-- 1. Partial unique index enforces unique execution_order within each
+--    artifact_type when execution_order is set. NULL execution_orders remain
+--    unconstrained so artifacts without an assigned slot can coexist freely
+--    (this preserves backward compatibility with v0.7.0 rows).
+--
+-- 2. GIN index on the dependencies array enables efficient reverse-lookup
+--    queries ("what artifacts depend on X?"). Full referential integrity via
+--    a junction table with foreign keys is deferred to v0.8; write-time
+--    validation in the MCP tools closes the immediate gap.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_type_exec_order_unique
+    ON artifacts (artifact_type, execution_order)
+    WHERE execution_order IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_dependencies
+    ON artifacts USING GIN (dependencies);

--- a/src/tools/artifacts.ts
+++ b/src/tools/artifacts.ts
@@ -101,8 +101,11 @@ async function validateDependenciesExist(
     "SELECT id FROM artifacts WHERE id = ANY($1::uuid[])",
     [deps]
   );
-  const found = new Set(result.rows.map((r) => r.id));
-  const missing = deps.filter((d) => !found.has(d));
+  // Postgres returns uuid values in canonical lowercase regardless of input
+  // casing. Compare case-insensitively so an uppercase or mixed-case input
+  // (still a valid UUID) is not falsely reported as missing.
+  const found = new Set(result.rows.map((r) => r.id.toLowerCase()));
+  const missing = deps.filter((d) => !found.has(d.toLowerCase()));
   return missing.length === 0 ? { valid: true } : { valid: false, missing };
 }
 

--- a/src/tools/artifacts.ts
+++ b/src/tools/artifacts.ts
@@ -81,6 +81,49 @@ function isValidStatusTransition(from: string, to: string): boolean {
   return Boolean(allowed && allowed.includes(to));
 }
 
+// Basic RFC-4122 UUID shape check. Postgres will reject anything else when
+// casting to uuid[], but catching it here gives us a clean VALIDATION_ERROR
+// instead of a raw DB_ERROR with a driver-level message.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Verify all UUIDs in a dependencies array exist as artifact rows. Returns
+ * an object indicating whether validation passed or listing the offending
+ * UUIDs. Caller is responsible for only invoking this when the array is
+ * non-empty and well-formed.
+ */
+async function validateDependenciesExist(
+  deps: string[]
+): Promise<{ valid: true } | { valid: false; missing: string[] }> {
+  if (deps.length === 0) return { valid: true };
+  const result = await query<{ id: string }>(
+    "SELECT id FROM artifacts WHERE id = ANY($1::uuid[])",
+    [deps]
+  );
+  const found = new Set(result.rows.map((r) => r.id));
+  const missing = deps.filter((d) => !found.has(d));
+  return missing.length === 0 ? { valid: true } : { valid: false, missing };
+}
+
+interface PgErrorShape {
+  code?: string;
+  constraint?: string;
+}
+
+/**
+ * Detect the execution_order uniqueness constraint violation so we can
+ * surface a clean EXECUTION_ORDER_CONFLICT instead of a raw DB_ERROR. All
+ * other 23505 scenarios still fall through to DB_ERROR.
+ */
+function isExecutionOrderConflict(err: unknown): boolean {
+  const pg = err as PgErrorShape;
+  return (
+    pg?.code === "23505" &&
+    pg?.constraint === "idx_artifacts_type_exec_order_unique"
+  );
+}
+
 // ── Zod Schemas ──────────────────────────────────────────────────
 
 const scopeEnum = z.enum(["work", "personal", "shared"]);
@@ -116,6 +159,10 @@ Status lifecycle:
 
 Use 'execution_order' to sequence artifacts within a batch (e.g., a chain of CC prompts where 1 builds infrastructure, 2 adds tests, 3 updates docs). Use 'dependencies' for explicit cross-artifact ordering when execution_order is not enough. Use 'metadata' for flexible fields like branch_target, model, surface, batch_label.
 
+Integrity:
+- 'execution_order' must be unique within an 'artifact_type'. Attempting to store a duplicate returns EXECUTION_ORDER_CONFLICT. Leave execution_order unset (null) if you do not need a fixed slot.
+- 'dependencies' UUIDs are validated at write time — all referenced artifacts must exist. Orphaned references return VALIDATION_ERROR.
+
 Returns {id, title, artifact_type, status, created_at}. Re-embeds on create; falls back to the pending queue if the embedding server is offline.`;
 
 const GET_ARTIFACT_DESC = `Retrieve a single artifact by its UUID. Returns the full artifact record including content, pointer, dependencies, and metadata.`;
@@ -138,6 +185,10 @@ Status transitions are enforced:
 - executing → completed, ready, superseded
 - completed → superseded
 - Any state → superseded (retirement)
+
+Integrity:
+- 'execution_order' must be unique within an 'artifact_type'. Moving an artifact onto an already-used slot returns EXECUTION_ORDER_CONFLICT.
+- 'dependencies' UUIDs are validated at write time. Pass an empty array to clear; any non-empty array must reference existing artifacts or returns VALIDATION_ERROR.
 
 Re-embeds when title, content, tags, or artifact_type change.`;
 
@@ -183,6 +234,30 @@ export function registerArtifactTools(mcpServer: McpServer): void {
         );
       }
 
+      if (args.dependencies && args.dependencies.length > 0) {
+        const malformed = args.dependencies.filter((d) => !UUID_RE.test(d));
+        if (malformed.length > 0) {
+          return errorResponse(
+            `Malformed UUID in dependencies: ${malformed.join(", ")}`,
+            "VALIDATION_ERROR"
+          );
+        }
+        try {
+          const check = await validateDependenciesExist(args.dependencies);
+          if (!check.valid) {
+            return errorResponse(
+              `Dependency artifact IDs do not exist: ${check.missing.join(", ")}`,
+              "VALIDATION_ERROR"
+            );
+          }
+        } catch (err) {
+          return errorResponse(
+            `Failed to validate dependencies: ${(err as Error).message}`,
+            "DB_ERROR"
+          );
+        }
+      }
+
       try {
         const result = await query<ArtifactRow>(
           `INSERT INTO artifacts (
@@ -225,6 +300,12 @@ export function registerArtifactTools(mcpServer: McpServer): void {
           created_at: row.created_at,
         });
       } catch (err) {
+        if (isExecutionOrderConflict(err)) {
+          return errorResponse(
+            `execution_order ${args.execution_order} is already used for artifact_type '${args.artifact_type}'`,
+            "EXECUTION_ORDER_CONFLICT"
+          );
+        }
         return errorResponse((err as Error).message, "DB_ERROR");
       }
     }
@@ -411,6 +492,7 @@ export function registerArtifactTools(mcpServer: McpServer): void {
       metadata: z.record(z.unknown()).optional().describe("Metadata to merge (top-level keys)"),
     },
     async (args) => {
+      let current: ArtifactRow;
       try {
         const existing = await query<ArtifactRow>(
           "SELECT * FROM artifacts WHERE id = $1",
@@ -419,29 +501,57 @@ export function registerArtifactTools(mcpServer: McpServer): void {
         if (existing.rows.length === 0) {
           return errorResponse(`Artifact not found: ${args.id}`, "NOT_FOUND");
         }
-        const current = existing.rows[0];
+        current = existing.rows[0];
+      } catch (err) {
+        return errorResponse((err as Error).message, "DB_ERROR");
+      }
 
-        if (args.status !== undefined && !isValidStatusTransition(current.status, args.status)) {
-          return errorResponse(
-            `Invalid status transition: ${current.status} → ${args.status}`,
-            "INVALID_STATUS_TRANSITION"
-          );
-        }
+      if (args.status !== undefined && !isValidStatusTransition(current.status, args.status)) {
+        return errorResponse(
+          `Invalid status transition: ${current.status} → ${args.status}`,
+          "INVALID_STATUS_TRANSITION"
+        );
+      }
 
-        // Ensure post-update we still have content or pointer.
-        const nextContent =
-          args.content !== undefined ? args.content : current.content;
-        const nextPointer =
-          args.pointer !== undefined ? args.pointer : current.pointer;
-        const hasContent = typeof nextContent === "string" && nextContent.trim().length > 0;
-        const hasPointer = nextPointer && typeof nextPointer === "object";
-        if (!hasContent && !hasPointer) {
+      // Ensure post-update we still have content or pointer.
+      const nextContent =
+        args.content !== undefined ? args.content : current.content;
+      const nextPointer =
+        args.pointer !== undefined ? args.pointer : current.pointer;
+      const hasContent = typeof nextContent === "string" && nextContent.trim().length > 0;
+      const hasPointer = nextPointer && typeof nextPointer === "object";
+      if (!hasContent && !hasPointer) {
+        return errorResponse(
+          "Artifact must retain either 'content' or 'pointer' after update",
+          "VALIDATION_ERROR"
+        );
+      }
+
+      if (args.dependencies !== undefined && args.dependencies.length > 0) {
+        const malformed = args.dependencies.filter((d) => !UUID_RE.test(d));
+        if (malformed.length > 0) {
           return errorResponse(
-            "Artifact must retain either 'content' or 'pointer' after update",
+            `Malformed UUID in dependencies: ${malformed.join(", ")}`,
             "VALIDATION_ERROR"
           );
         }
+        try {
+          const check = await validateDependenciesExist(args.dependencies);
+          if (!check.valid) {
+            return errorResponse(
+              `Dependency artifact IDs do not exist: ${check.missing.join(", ")}`,
+              "VALIDATION_ERROR"
+            );
+          }
+        } catch (err) {
+          return errorResponse(
+            `Failed to validate dependencies: ${(err as Error).message}`,
+            "DB_ERROR"
+          );
+        }
+      }
 
+      try {
         const sets: string[] = [];
         const params: unknown[] = [];
         let paramIdx = 1;
@@ -523,6 +633,17 @@ export function registerArtifactTools(mcpServer: McpServer): void {
 
         return jsonResponse(formatArtifact(row));
       } catch (err) {
+        if (isExecutionOrderConflict(err)) {
+          const effectiveType = args.artifact_type ?? current.artifact_type;
+          const effectiveOrder =
+            args.execution_order !== undefined
+              ? args.execution_order
+              : current.execution_order;
+          return errorResponse(
+            `execution_order ${effectiveOrder} is already used for artifact_type '${effectiveType}'`,
+            "EXECUTION_ORDER_CONFLICT"
+          );
+        }
         return errorResponse((err as Error).message, "DB_ERROR");
       }
     }


### PR DESCRIPTION
## Summary

Two integrity fixes for the v0.7.0 artifact layer, surfaced during PR #39 review.

- **execution_order uniqueness:** Partial unique index on `(artifact_type, execution_order)` where `execution_order IS NOT NULL`. `store_artifact` and `update_artifact` return `EXECUTION_ORDER_CONFLICT` when a duplicate is attempted. Null slots remain unconstrained so existing v0.7.0 rows keep working.
- **dependencies validation:** Write-time existence check on `dependencies` UUIDs in `store_artifact` and `update_artifact`. Non-existent references return `VALIDATION_ERROR`; malformed UUIDs caught before the postgres cast. Empty array clears dependencies on update. Also adds a GIN index on `dependencies` for efficient reverse-lookup queries. Full referential integrity (junction table with FKs) deferred to v0.8.

Migration `008_artifact_integrity.sql` combines both index additions.

Closes #40
Closes #44

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm test` without Postgres: 155 passed, 100 skipped (new cases skip gracefully via `describe.skipIf`)
- [x] `npm test` with Postgres: **255 passed, 0 failures** (8 new cases + 247 existing)
- [x] Migration 008 applies cleanly on a fresh database
- [x] Migration 008 applies cleanly on top of populated v0.7.0 data (including rows with null `execution_order`)
- [x] Migration 008 is idempotent — second apply emits NOTICE + no-op
- [x] Duplicate execution_order insert now fails with the unique constraint, which the tool translates to `EXECUTION_ORDER_CONFLICT`
- [x] `EXECUTION_ORDER_CONFLICT` is returned only for the specific constraint — other unique-violation scenarios still surface as `DB_ERROR`
- [x] Tool descriptions updated in both `store_artifact` and `update_artifact`
- [x] Version bumped to `0.7.1` in `package.json` and `package-lock.json`
- [x] ROADMAP updated with v0.7.1 section + v0.8 line for future junction-table work
- [x] PII audit: all new fixtures use generic placeholders (`dup-order-*`, `cc-prompt`, `type-a-*`, opaque UUIDs); no real names/domains introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)