### PR TITLE
ci: use docker/login-action for GHCR authentication

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -64,7 +64,11 @@ jobs:
             --exclude-base-image-vulns
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push SHA-tagged image to GHCR
         run: docker push ghcr.io/onideus/context-library:sha-${{ steps.sha.outputs.short_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify SHA image exists
         run: |


### PR DESCRIPTION
## Summary

Replace raw `docker login ... --password-stdin` with `docker/login-action@v3` in both `image.yml` and `release.yml`. Eliminates the `WARNING! Your credentials are stored unencrypted` message from CI logs and aligns with the idiomatic GitHub Actions pattern.

Not a security fix — runners are ephemeral and `GITHUB_TOKEN` is job-scoped. Purely CI log hygiene.

Pinned to `c94ce9fb468520275223c153574b00df6fe4bcc9` (v3.7.0), matching the existing full-SHA + trailing-tag-comment convention used for `actions/checkout` and `snyk/actions/setup`.

## Test plan

- [x] YAML parses clean (Python `yaml.safe_load`; actionlint/yamllint not available locally)
- [x] Diff is strictly the login step in both files — no drive-by edits
- [x] SHA pins match existing action-pinning convention
- [ ] After merge: next push to \`main\` triggers \`image.yml\`; verify the warning is absent from the run log
- [ ] After merge: warning verification for \`release.yml\` deferred to the next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)