### PR TITLE
fix: ci failures from content_hash artifact-lock changes

### DIFF
--- a/scripts/backfill-content-hashes.ts
+++ b/scripts/backfill-content-hashes.ts
@@ -14,7 +14,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { query } from "../src/db/client.js";
+import { pool, query } from "../src/db/client.js";
 
 function computeContentHash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
@@ -69,7 +69,9 @@ async function backfill(): Promise<void> {
   // distinguish between a complete failure and a partial backfill.
 }
 
-backfill().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+backfill()
+  .catch((err) => {
+    console.error("Fatal error:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/src/__tests__/artifacts.test.ts
+++ b/src/__tests__/artifacts.test.ts
@@ -777,7 +777,8 @@ describe.skipIf(!pgAvailable)("Artifact Tools", () => {
         content: "immutable content",
         status: "ready",
       });
-      const legitimateHash = created.metadata.content_hash;
+      const fetched = await callTool("get_artifact", { id: created.id });
+      const legitimateHash = fetched.metadata.content_hash;
       expect(legitimateHash).toBeDefined();
 
       // Attempt to overwrite the hash via a metadata update

--- a/src/__tests__/backfill-content-hashes.test.ts
+++ b/src/__tests__/backfill-content-hashes.test.ts
@@ -158,6 +158,10 @@ describe.skipIf(!pgAvailable)("backfill-content-hashes script", () => {
     await client.end();
   });
 
+  // Each case spawns `npx tsx` against a real DB, which can exceed the
+  // 5-second default in CI. Bump the per-test timeout to 30s.
+  const SCRIPT_TIMEOUT_MS = 30_000;
+
   describe("population", () => {
     it("adds content_hash to locked artifacts that are missing it", async () => {
       const content1 = "ready artifact content";
@@ -191,7 +195,7 @@ describe.skipIf(!pgAvailable)("backfill-content-hashes script", () => {
         "SELECT metadata FROM artifacts WHERE status = 'draft'"
       );
       expect(draft.rows[0].metadata.content_hash).toBeUndefined();
-    });
+    }, SCRIPT_TIMEOUT_MS);
 
     it("handles pointer-only artifacts (null content) by hashing empty string", async () => {
       await client.query(`
@@ -206,7 +210,7 @@ describe.skipIf(!pgAvailable)("backfill-content-hashes script", () => {
         "SELECT metadata FROM artifacts WHERE title = 'Pointer-only'"
       );
       expect(row.rows[0].metadata.content_hash).toBe(sha256(""));
-    });
+    }, SCRIPT_TIMEOUT_MS);
   });
 
   describe("idempotency", () => {
@@ -232,7 +236,7 @@ describe.skipIf(!pgAvailable)("backfill-content-hashes script", () => {
           before.rows[i].metadata.content_hash
         );
       }
-    });
+    }, SCRIPT_TIMEOUT_MS);
 
     it("exits 0 even when no locked artifacts exist", async () => {
       // Use a fresh table with only draft artifacts
@@ -240,6 +244,6 @@ describe.skipIf(!pgAvailable)("backfill-content-hashes script", () => {
       const result = runBackfill();
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("0 updated");
-    });
+    }, SCRIPT_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## Summary
Two CI regressions surfaced by #85 (Pipeline hardening 08a — content_hash on artifact lock):

- **`artifacts.test.ts` — `update_artifact silently ignores content_hash supplied in metadata on a locked artifact`** failed with `TypeError: Cannot read properties of undefined (reading 'content_hash')`. The test read `created.metadata.content_hash`, but `store_artifact` only returns `{id, title, artifact_type, status, created_at}`. Added a `get_artifact` call to fetch the legitimate hash, matching the pattern used by the neighboring "pointer-only artifact" test.
- **`backfill-content-hashes.test.ts` — all 4 tests timed out at 5000ms.** Two issues compounded:
  1. `scripts/backfill-content-hashes.ts` never called `pool.end()`, so the spawned `npx tsx` child kept the event loop alive on idle pg sockets and the `spawnSync` call never returned.
  2. Even with a clean exit, `npx tsx` startup + DB work in CI routinely exceeds vitest's 5s default. Added per-test timeouts of 30s to match the existing 30s `spawnSync` budget.

## Test plan
- [x] `npm run build` — passes
- [x] `npm test -- --run` locally (PG-dependent suites skip without local Postgres) — 165 passed, 117 skipped, 0 failed
- [ ] CI green on this PR (verifies the PG-dependent backfill suite under the bumped timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)