### PR TITLE
Bump hono and fast-uri to fix Snyk high-severity CI failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,9 +1566,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

The two most recent runs on `main` ([ci](https://github.com/onideus/context-library/actions/runs/28556185967) and [image](https://github.com/onideus/context-library/actions/runs/28556186012)) failed at the Snyk dependency scan due to three newly published high-severity advisories — not test failures. The same commit had passed on its PR ~30 minutes earlier; the advisories landed in between.

## Changes

Lockfile-only bumps, both within existing semver ranges:

- **hono 4.12.18 → 4.12.27** — fixes Directory Traversal ([SNYK-JS-HONO-17356405](https://security.snyk.io/vuln/SNYK-JS-HONO-17356405), CVE-2026-54286) and Permissive Cross-domain Policy ([SNYK-JS-HONO-17356430](https://security.snyk.io/vuln/SNYK-JS-HONO-17356430)); both fixed in 4.12.25+
- **fast-uri 3.1.2 → 3.1.3** (transitive via ajv) — fixes Interpretation Conflict ([SNYK-JS-FASTURI-17675102](https://security.snyk.io/vuln/SNYK-JS-FASTURI-17675102), CVE-2026-13676)

## Verification

- `npm run build` passes
- Unit + server integration suites pass locally (107 tests), including `server.test.ts` which spawns the real Hono server
- Postgres-gated suites fail identically on unmodified `main` locally (pre-existing local environment issue, unrelated to this change); they pass in CI against the service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)